### PR TITLE
feat: custom background image support

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2465,9 +2465,10 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nextdialog"
-version = "0.1.0"
+version = "0.2.2"
 dependencies = [
  "arboard",
+ "base64 0.22.1",
  "chrono",
  "dirs 5.0.1",
  "png 0.17.16",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ chrono = { version = "0.4", features = ["serde"] }
 png = "0.17"
 reqwest = { version = "0.12", features = ["json", "blocking", "rustls-tls"] }
 tiny_http = "0.12"
+base64 = "0.22"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,3 +1,8 @@
+use std::fs;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use tauri::{AppHandle, State};
 
 use crate::clipboard::bridge::save_clipboard_image;
@@ -327,6 +332,103 @@ pub fn track_event(
 #[tauri::command]
 pub fn flush_telemetry(telemetry: State<'_, TelemetryClient>) -> Result<(), String> {
     telemetry.flush()
+}
+
+// ── Background Image ──
+
+#[tauri::command]
+pub fn import_background_image(
+    settings_manager: State<'_, SettingsManager>,
+    source_path: String,
+) -> Result<String, String> {
+    let source = Path::new(&source_path);
+    if !source.exists() {
+        return Err("File does not exist".to_string());
+    }
+
+    let ext = source
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_lowercase())
+        .unwrap_or_default();
+
+    if !matches!(ext.as_str(), "jpg" | "jpeg" | "png" | "webp") {
+        return Err("Unsupported image format. Use jpg, png, or webp.".to_string());
+    }
+
+    let bg_dir = dirs::home_dir()
+        .ok_or("Could not determine home directory")?
+        .join(".nextdialog")
+        .join("backgrounds");
+
+    fs::create_dir_all(&bg_dir).map_err(|e| format!("Failed to create backgrounds dir: {e}"))?;
+
+    // Delete previous background image if one exists
+    let current_settings = settings_manager.get();
+    if !current_settings.background_image_path.is_empty() {
+        let old_path = bg_dir.join(&current_settings.background_image_path);
+        let _ = fs::remove_file(old_path);
+    }
+
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let filename = format!("background_{timestamp}.{ext}");
+    let dest = bg_dir.join(&filename);
+
+    fs::copy(source, &dest).map_err(|e| format!("Failed to copy image: {e}"))?;
+
+    let mut settings = current_settings;
+    settings.background_mode = "image".to_string();
+    settings.background_image_path = filename;
+    settings_manager.save(settings);
+
+    // Return as data URL so the frontend can display immediately
+    let data = fs::read(&dest).map_err(|e| format!("Failed to read copied image: {e}"))?;
+    let mime = match ext.as_str() {
+        "png" => "image/png",
+        "webp" => "image/webp",
+        _ => "image/jpeg",
+    };
+    Ok(format!("data:{};base64,{}", mime, BASE64.encode(&data)))
+}
+
+#[tauri::command]
+pub fn reset_background(settings_manager: State<'_, SettingsManager>) {
+    let mut settings = settings_manager.get();
+    settings.background_mode = "gradient".to_string();
+    settings.background_image_path = String::new();
+    settings_manager.save(settings);
+}
+
+#[tauri::command]
+pub fn get_background_image_data(
+    settings_manager: State<'_, SettingsManager>,
+) -> Option<String> {
+    let settings = settings_manager.get();
+    if settings.background_mode != "image" || settings.background_image_path.is_empty() {
+        return None;
+    }
+    let path = dirs::home_dir()?
+        .join(".nextdialog")
+        .join("backgrounds")
+        .join(&settings.background_image_path);
+    if !path.exists() {
+        return None;
+    }
+    let data = fs::read(&path).ok()?;
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("jpeg")
+        .to_lowercase();
+    let mime = match ext.as_str() {
+        "png" => "image/png",
+        "webp" => "image/webp",
+        _ => "image/jpeg",
+    };
+    Some(format!("data:{};base64,{}", mime, BASE64.encode(&data)))
 }
 
 // ── Diagnostics ──

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -94,6 +94,9 @@ pub fn run() {
             commands::track_event,
             commands::flush_telemetry,
             commands::get_hook_status,
+            commands::import_background_image,
+            commands::reset_background,
+            commands::get_background_image_data,
         ])
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::Destroyed = event {

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -29,6 +29,10 @@ pub struct Settings {
     pub hook_port_start: u16,
     #[serde(default = "default_hook_port_end")]
     pub hook_port_end: u16,
+    #[serde(default = "default_background_mode")]
+    pub background_mode: String,
+    #[serde(default)]
+    pub background_image_path: String,
 }
 
 fn default_hooks_enabled() -> bool {
@@ -41,6 +45,10 @@ fn default_hook_port_start() -> u16 {
 
 fn default_hook_port_end() -> u16 {
     7499
+}
+
+fn default_background_mode() -> String {
+    "gradient".to_string()
 }
 
 impl Default for Settings {
@@ -57,6 +65,8 @@ impl Default for Settings {
             hooks_enabled: true,
             hook_port_start: 7432,
             hook_port_end: 7499,
+            background_mode: "gradient".to_string(),
+            background_image_path: String::new(),
         }
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'"
+      "csp": "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'"
     }
   },
   "bundle": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useMemo, useEffect, useRef, Component, type Reac
 import { invoke } from "@tauri-apps/api/core";
 import type { Session } from "./lib/types";
 import { SessionProvider } from "./context/SessionContext";
-import { ShiftingGradient } from "./components/ShiftingGradient";
+import { AppBackground } from "./components/AppBackground";
 import { HomeView } from "./components/HomeView";
 import { NewSessionModal } from "./components/NewSessionModal";
 import { TerminalOverlay } from "./components/TerminalOverlay";
@@ -83,6 +83,33 @@ function AppContent() {
     }
     return map;
   }, [sessions]);
+
+  const [backgroundMode, setBackgroundMode] = useState("gradient");
+  const [backgroundImageUrl, setBackgroundImageUrl] = useState<string | null>(null);
+
+  // Load background settings on mount
+  useEffect(() => {
+    invoke<{ background_mode: string; background_image_path: string }>("get_settings")
+      .then((s) => {
+        setBackgroundMode(s.background_mode || "gradient");
+        if (s.background_mode === "image" && s.background_image_path) {
+          invoke<string | null>("get_background_image_data").then((dataUrl) => {
+            if (dataUrl) {
+              setBackgroundImageUrl(dataUrl);
+            } else {
+              // Image file was deleted — fall back to gradient
+              setBackgroundMode("gradient");
+            }
+          });
+        }
+      })
+      .catch(console.error);
+  }, []);
+
+  const handleBackgroundChange = useCallback((mode: string, imageUrl: string | null) => {
+    setBackgroundMode(mode);
+    setBackgroundImageUrl(imageUrl);
+  }, []);
 
   const [recentSessions, setRecentSessions] = useState<RecentSession[]>(() =>
     getRecentSessions(),
@@ -357,7 +384,11 @@ function AppContent() {
 
   return (
     <>
-      <ShiftingGradient sessionStatuses={sessions.map((s) => s.status)} />
+      <AppBackground
+        sessionStatuses={sessions.map((s) => s.status)}
+        backgroundMode={backgroundMode}
+        backgroundImageUrl={backgroundImageUrl}
+      />
       <HomeView
         sessions={activeSessions}
         onNewSession={() => setShowNewSession(true)}
@@ -400,6 +431,8 @@ function AppContent() {
         onUpdateType={updateType}
         onCreateType={createType}
         onDeleteType={deleteType}
+        backgroundMode={backgroundMode}
+        onBackgroundChange={handleBackgroundChange}
       />
       {spawnedIds.map((id) => {
         const session = sessions.find((s) => s.id === id);

--- a/src/components/AppBackground.tsx
+++ b/src/components/AppBackground.tsx
@@ -1,0 +1,37 @@
+import { ShiftingGradient } from "./ShiftingGradient";
+import type { SessionStatus } from "../lib/types";
+
+interface AppBackgroundProps {
+  sessionStatuses?: SessionStatus[];
+  backgroundMode: string;
+  backgroundImageUrl: string | null;
+}
+
+export function AppBackground({
+  sessionStatuses,
+  backgroundMode,
+  backgroundImageUrl,
+}: AppBackgroundProps) {
+  if (backgroundMode === "image" && backgroundImageUrl) {
+    return (
+      <div className="fixed -z-10 inset-0">
+        <img
+          src={backgroundImageUrl}
+          alt=""
+          className="absolute inset-0 w-full h-full object-cover"
+        />
+        <div className="absolute inset-0 background-scrim" />
+        {/* Dot grid overlay — matches gradient mode */}
+        <div
+          className="absolute inset-0 opacity-[0.015]"
+          style={{
+            backgroundImage: "radial-gradient(circle, #000 1px, transparent 1px)",
+            backgroundSize: "24px 24px",
+          }}
+        />
+      </div>
+    );
+  }
+
+  return <ShiftingGradient sessionStatuses={sessionStatuses} />;
+}

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -20,6 +20,8 @@ interface Settings {
   hooks_enabled: boolean;
   hook_port_start: number;
   hook_port_end: number;
+  background_mode: string;
+  background_image_path: string;
 }
 
 interface SettingsViewProps {
@@ -29,6 +31,8 @@ interface SettingsViewProps {
   onUpdateType?: (sessionType: SessionType) => Promise<unknown>;
   onCreateType?: (sessionType: SessionType) => Promise<unknown>;
   onDeleteType?: (id: string) => Promise<void>;
+  backgroundMode?: string;
+  onBackgroundChange?: (mode: string, imageUrl: string | null) => void;
 }
 
 export function SettingsView({
@@ -38,6 +42,8 @@ export function SettingsView({
   onUpdateType,
   onCreateType,
   onDeleteType,
+  backgroundMode = "gradient",
+  onBackgroundChange,
 }: SettingsViewProps) {
   const [settings, setSettings] = useState<Settings>({
     default_directory: "",
@@ -51,6 +57,8 @@ export function SettingsView({
     hooks_enabled: true,
     hook_port_start: 7432,
     hook_port_end: 7499,
+    background_mode: "gradient",
+    background_image_path: "",
   });
 
   const [showAddForm, setShowAddForm] = useState(false);
@@ -59,11 +67,22 @@ export function SettingsView({
   const [newCommand, setNewCommand] = useState("");
   const [newIcon, setNewIcon] = useState("");
   const [newColor, setNewColor] = useState("#6366f1");
+  const [bgPreviewUrl, setBgPreviewUrl] = useState<string | null>(null);
 
   useEffect(() => {
     if (isOpen) {
       invoke<Settings>("get_settings")
-        .then(setSettings)
+        .then((s) => {
+          setSettings(s);
+          // Load preview thumbnail if custom background is active
+          if (s.background_mode === "image" && s.background_image_path) {
+            invoke<string | null>("get_background_image_data").then((dataUrl) => {
+              setBgPreviewUrl(dataUrl ?? null);
+            });
+          } else {
+            setBgPreviewUrl(null);
+          }
+        })
         .catch(console.error);
       setShowAddForm(false);
     }
@@ -162,6 +181,73 @@ export function SettingsView({
                   >
                     Browse
                   </button>
+                </div>
+              </div>
+
+              {/* Appearance */}
+              <div className="border-t border-slate-200 pt-4">
+                <h3 className="text-sm font-semibold text-slate-700 mb-3">
+                  Appearance
+                </h3>
+                <div className="flex items-center gap-3">
+                  {/* Preview thumbnail */}
+                  <div className="w-16 h-10 rounded-md overflow-hidden border border-slate-200 bg-gradient-to-br from-orange-100 via-rose-50 to-violet-100 shrink-0">
+                    {bgPreviewUrl && backgroundMode === "image" && (
+                      <img
+                        src={bgPreviewUrl}
+                        alt="Background preview"
+                        className="w-full h-full object-cover"
+                      />
+                    )}
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={async () => {
+                        const selected = await open({
+                          multiple: false,
+                          filters: [
+                            {
+                              name: "Images",
+                              extensions: ["jpg", "jpeg", "png", "webp"],
+                            },
+                          ],
+                        });
+                        if (selected) {
+                          try {
+                            const dataUrl = await invoke<string>(
+                              "import_background_image",
+                              { sourcePath: selected as string },
+                            );
+                            setBgPreviewUrl(dataUrl);
+                            onBackgroundChange?.("image", dataUrl);
+                          } catch (err) {
+                            console.error("Failed to import background:", err);
+                          }
+                        }
+                      }}
+                      className="px-3 py-1.5 rounded-lg bg-slate-100 text-slate-600 text-xs hover:bg-slate-200 transition-colors"
+                    >
+                      Choose Image...
+                    </button>
+                    {backgroundMode === "image" && (
+                      <button
+                        type="button"
+                        onClick={async () => {
+                          try {
+                            await invoke("reset_background");
+                            setBgPreviewUrl(null);
+                            onBackgroundChange?.("gradient", null);
+                          } catch (err) {
+                            console.error("Failed to reset background:", err);
+                          }
+                        }}
+                        className="px-3 py-1.5 rounded-lg text-slate-400 text-xs hover:text-slate-600 transition-colors"
+                      >
+                        Reset to Default
+                      </button>
+                    )}
+                  </div>
                 </div>
               </div>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -90,6 +90,12 @@ body,
     inset 0 1px 0 rgba(255, 255, 255, 0.9);
 }
 
+.background-scrim {
+  background: rgba(251, 245, 243, 0.55);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
 @keyframes breathe {
   from { transform: scale(1) rotate(0deg); }
   to { transform: scale(1.03) rotate(1deg); }


### PR DESCRIPTION
## Summary
- Users can set a custom background image via **Settings > Appearance**
- Images are imported to `~/.nextdialog/backgrounds/`, served as base64 data URLs
- Warm-cream scrim overlay (`rgba(251,245,243,0.55)` + `blur(8px)`) preserves glass morphism on any photo
- Graceful fallback to animated gradient if image file is missing

## Changes
- **Rust**: `background_mode` / `background_image_path` settings fields, 3 new commands (`import_background_image`, `reset_background`, `get_background_image_data`)
- **Frontend**: New `AppBackground` component, Appearance section in SettingsView, CSP allows `data:` img-src
- **CSS**: `.background-scrim` class

## Test plan
- [ ] Fresh launch → animated gradient works as default
- [ ] Settings → Appearance → Choose Image → background updates immediately
- [ ] Glass cards remain readable over custom image
- [ ] Close/reopen app → custom background persists
- [ ] Reset to Default → gradient returns
- [ ] Delete image from `~/.nextdialog/backgrounds/` → graceful fallback to gradient
- [ ] `cargo build` + `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)