### PR TITLE
fix: address critical session bugs #7, #8, #11

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, Emitter, State};
 
 use crate::clipboard::bridge::save_clipboard_image;
 use crate::hooks::manager::HookManager;
@@ -185,6 +185,9 @@ pub fn restart_pty_session(
 
     // Teardown old hooks before restart
     hook_manager.teardown_session(&id);
+
+    // Signal frontend to clear the terminal buffer before new PTY output arrives
+    let _ = app_handle.emit(&format!("pty-restart-{id}"), ());
 
     pool.restart(
         &id,
@@ -446,6 +449,19 @@ pub fn get_hook_status(
     id: String,
 ) -> bool {
     hook_manager.is_active(&id)
+}
+
+// ── Binary Availability ──
+
+#[tauri::command]
+pub fn check_binary_available(command: String) -> bool {
+    // Extract just the binary name (first word) from multi-word commands like "openclaw tui"
+    let binary = command.split_whitespace().next().unwrap_or(&command);
+    std::process::Command::new("which")
+        .arg(binary)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
 }
 
 // ── Intelligence ──

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -94,6 +94,7 @@ pub fn run() {
             commands::track_event,
             commands::flush_telemetry,
             commands::get_hook_status,
+            commands::check_binary_available,
             commands::import_background_image,
             commands::reset_background,
             commands::get_background_image_data,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -128,17 +128,22 @@ function AppContent() {
   const spawningRef = useRef<Set<string>>(new Set());
 
   const handleSelectSession = useCallback(async (id: string) => {
-    setActiveSessionId(id);
-    trackEvent("session.focused", "session-management", undefined, id);
-    if (spawningRef.current.has(id)) return;
+    if (spawningRef.current.has(id)) {
+      // Already spawning — just focus
+      setActiveSessionId(id);
+      return;
+    }
     spawningRef.current.add(id);
     trackEvent("session.opened", "session-management", undefined, id);
     try {
       await invoke("spawn_pty_session", { id, rows: null, cols: null });
       setSpawnedIds((prev) => (prev.includes(id) ? prev : [...prev, id]));
+      setActiveSessionId(id);
+      trackEvent("session.focused", "session-management", undefined, id);
     } catch (err) {
       console.error("Failed to spawn PTY:", err);
       spawningRef.current.delete(id);
+      // Don't set activeSessionId — prevents blank screen on spawn failure
     }
   }, []);
 

--- a/src/components/NewSessionModal.tsx
+++ b/src/components/NewSessionModal.tsx
@@ -59,7 +59,7 @@ export function NewSessionModal({
   sessionTypes = [],
 }: NewSessionModalProps) {
   const enabledTypes = useMemo(
-    () => sessionTypes.filter((t) => t.enabled),
+    () => sessionTypes.filter((t) => t.enabled && t.available !== false),
     [sessionTypes],
   );
 

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -272,6 +272,11 @@ export function SettingsView({
                             built-in
                           </span>
                         )}
+                        {st.available === false && (
+                          <span className="text-[10px] px-1.5 py-0.5 rounded bg-red-50 text-red-400 shrink-0">
+                            not found
+                          </span>
+                        )}
                       </div>
                       <div className="flex items-center gap-2 shrink-0">
                         {!st.builtin && onDeleteType && (

--- a/src/hooks/useSessionTypes.ts
+++ b/src/hooks/useSessionTypes.ts
@@ -8,7 +8,21 @@ export function useSessionTypes() {
   const load = useCallback(async () => {
     try {
       const types = await invoke<SessionType[]>("list_session_types");
-      setSessionTypes(types);
+
+      // Check which binaries are actually available on PATH
+      const availabilityChecks = await Promise.all(
+        types.map((t) =>
+          invoke<boolean>("check_binary_available", { command: t.command })
+            .catch(() => false),
+        ),
+      );
+
+      const typesWithAvailability = types.map((t, i) => ({
+        ...t,
+        available: availabilityChecks[i],
+      }));
+
+      setSessionTypes(typesWithAvailability);
     } catch (err) {
       console.error("Failed to load session types:", err);
     }

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -231,8 +231,30 @@ export function useTerminal({
       unlistenData = fn;
     });
 
+    // Clear terminal when session is restarted (prevents cross-corruption)
+    let unlistenRestart: UnlistenFn | null = null;
+    listen(`pty-restart-${sessionId}`, () => {
+      term.clear();
+      term.reset();
+    }).then((fn) => {
+      unlistenRestart = fn;
+    });
+
+    const spawnTime = Date.now();
+
     listen(`pty-exit-${sessionId}`, () => {
-      term.write("\r\n\x1b[90m[Session ended]\x1b[0m\r\n");
+      const aliveMs = Date.now() - spawnTime;
+      if (aliveMs < 3000) {
+        // Process exited almost immediately — likely command not found or crash
+        term.write(
+          "\r\n\x1b[31m[Session exited immediately]\x1b[0m\r\n" +
+          "\x1b[90mThe process exited within " + Math.round(aliveMs / 1000) + "s of starting.\r\n" +
+          "This usually means the command was not found on your PATH.\r\n" +
+          "Check that the tool is installed and accessible from your shell.\x1b[0m\r\n",
+        );
+      } else {
+        term.write("\r\n\x1b[90m[Session ended]\x1b[0m\r\n");
+      }
     }).then((fn) => {
       unlistenExit = fn;
     });
@@ -240,7 +262,12 @@ export function useTerminal({
     return () => {
       unlistenData?.();
       unlistenExit?.();
-      term.dispose();
+      unlistenRestart?.();
+      try {
+        term.dispose();
+      } catch (err) {
+        console.warn("[useTerminal] dispose error (safe to ignore):", err);
+      }
       termRef.current = null;
       fitAddonRef.current = null;
       initRef.current = false;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -61,4 +61,6 @@ export interface SessionType {
   builtin: boolean;
   enabled: boolean;
   agent_config: AgentConfig;
+  /** Runtime flag — true if the command binary exists on PATH. Set by useSessionTypes, not persisted. */
+  available?: boolean;
 }


### PR DESCRIPTION
## Summary

- **Binary availability check** — validates commands exist on PATH at startup, only shows installable session types in the new session modal. Shows "not found" badge in Settings for missing tools.
- **Graceful spawn failures** — no more blank screen when a tool isn't installed. Terminal shows a clear error message if the process exits within 3 seconds.
- **Cross-corruption prevention** — terminal buffer is cleared on session restart, preventing old content from bleeding through.

## Test plan

- [ ] Install NextDialog fresh without `openclaw` installed — OpenClaw should not appear in new session modal
- [ ] Create a session for a type whose command doesn't exist — should see error message, not blank screen
- [ ] End a session, restart it — terminal should show fresh content, not old session's output
- [ ] Verify Claude Code sessions still work normally with the changes

Closes #7, closes #8, closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)