### PR TITLE
fix: redesign terminal overlay navigation UX

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -352,12 +352,15 @@ function AppContent() {
         },
         {
           label: "Restart",
+          shortcut: "⌘R",
           onClick: () => handleRestartSession(contextMenu.id),
         },
         {
           label: sessions.find((s) => s.id === contextMenu.id)?.parked
             ? "Unpark"
             : "Park",
+          shortcut: "⌘P",
+          dividerAfter: true,
           onClick: () => {
             const s = sessions.find((s) => s.id === contextMenu.id);
             if (s?.parked) {
@@ -369,6 +372,8 @@ function AppContent() {
         },
         {
           label: "End Session",
+          shortcut: "⌘⇧E",
+          dividerAfter: true,
           onClick: () => handleEndSession(contextMenu.id),
         },
         {
@@ -452,6 +457,7 @@ function AppContent() {
             onEnd={handleEndSession}
             onRestart={handleRestartSession}
             onRemove={handleRemoveSession}
+            onPark={handleParkSession}
             onAddCompanion={handleAddCompanion}
             onRemoveCompanion={handleRemoveCompanion}
           />

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -5,6 +5,8 @@ interface ContextMenuItem {
   label: string;
   onClick: () => void;
   variant?: "default" | "danger";
+  shortcut?: string;
+  dividerAfter?: boolean;
 }
 
 interface ContextMenuProps {
@@ -56,21 +58,28 @@ export function ContextMenu({
           className="fixed z-[100] min-w-[160px] rounded-lg bg-white/90 backdrop-blur-xl shadow-xl border border-slate-200/60 py-1 overflow-hidden"
           style={{ left: x, top: y }}
         >
-          {items.map((item) => (
-            <button
-              key={item.label}
-              onClick={() => {
-                item.onClick();
-                onClose();
-              }}
-              className={`w-full text-left px-3 py-1.5 text-sm transition-colors ${
-                item.variant === "danger"
-                  ? "text-red-600 hover:bg-red-50"
-                  : "text-slate-700 hover:bg-slate-100"
-              }`}
-            >
-              {item.label}
-            </button>
+          {items.map((item, idx) => (
+            <div key={item.label}>
+              <button
+                onClick={() => {
+                  item.onClick();
+                  onClose();
+                }}
+                className={`w-full text-left px-3 py-1.5 text-sm transition-colors flex items-center justify-between gap-4 ${
+                  item.variant === "danger"
+                    ? "text-red-600 hover:bg-red-50"
+                    : "text-slate-700 hover:bg-slate-100"
+                }`}
+              >
+                <span>{item.label}</span>
+                {item.shortcut && (
+                  <span className="text-xs text-slate-400 ml-auto">{item.shortcut}</span>
+                )}
+              </button>
+              {item.dividerAfter && idx < items.length - 1 && (
+                <div className="border-t border-slate-200/60 my-1" />
+              )}
+            </div>
           ))}
         </motion.div>
       )}

--- a/src/components/TerminalOverlay.tsx
+++ b/src/components/TerminalOverlay.tsx
@@ -15,6 +15,7 @@ interface TerminalOverlayProps {
   onEnd: (id: string) => void;
   onRestart: (id: string) => void;
   onRemove: (id: string) => void;
+  onPark: (id: string) => void;
   onAddCompanion: (parentId: string) => void;
   onRemoveCompanion: (id: string) => void;
 }
@@ -27,18 +28,16 @@ export function TerminalOverlay({
   onEnd,
   onRestart,
   onRemove,
+  onPark,
   onAddCompanion,
   onRemoveCompanion,
 }: TerminalOverlayProps) {
   const [activeTabId, setActiveTabId] = useState(session.id);
   const [showMenu, setShowMenu] = useState(false);
-  const lastEscapeRef = useRef(0);
   const paneRefs = useRef<Map<string, TerminalPaneHandle>>(new Map());
 
   const allTabs = [session, ...companions];
   const activeSession = allTabs.find((t) => t.id === activeTabId) ?? session;
-  const isStopped = activeSession.status === "stopped" || activeSession.status === "ready";
-
   // Reset to primary tab if active tab was removed
   useEffect(() => {
     if (!allTabs.some((t) => t.id === activeTabId)) {
@@ -50,18 +49,39 @@ export function TerminalOverlay({
   useEffect(() => {
     if (!isOpen) return;
     const handler = (e: KeyboardEvent) => {
+      // Escape only closes the actions menu — never the overlay
       if (e.key === "Escape") {
         if (showMenu) {
           setShowMenu(false);
-          return;
         }
-        const now = Date.now();
-        if (now - lastEscapeRef.current < 400) {
-          onClose();
-          lastEscapeRef.current = 0;
-        } else {
-          lastEscapeRef.current = now;
-        }
+        return;
+      }
+
+      // ⌘← or ⌘Backspace → back to home
+      if (e.metaKey && (e.key === "ArrowLeft" || e.key === "Backspace") && !e.shiftKey) {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+
+      // ⌘R → restart
+      if (e.metaKey && e.key === "r" && !e.shiftKey) {
+        e.preventDefault();
+        onRestart(session.id);
+        return;
+      }
+
+      // ⌘P → park session
+      if (e.metaKey && e.key === "p" && !e.shiftKey) {
+        e.preventDefault();
+        onPark(session.id);
+        return;
+      }
+
+      // ⌘⇧E → end session
+      if (e.metaKey && e.shiftKey && e.key === "E") {
+        e.preventDefault();
+        onEnd(session.id);
         return;
       }
 
@@ -97,7 +117,7 @@ export function TerminalOverlay({
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [isOpen, onClose, showMenu, session, companions, activeTabId, onAddCompanion, onRemoveCompanion]);
+  }, [isOpen, onClose, onRestart, onPark, onEnd, showMenu, session, companions, activeTabId, onAddCompanion, onRemoveCompanion]);
 
   // Drag-drop file handling — writes to active tab
   useEffect(() => {
@@ -156,7 +176,6 @@ export function TerminalOverlay({
         initial={false}
         animate={{ backdropFilter: isOpen ? "blur(8px)" : "blur(0px)" }}
         transition={{ duration: 0.4, ease: [0.25, 0.8, 0.25, 1] }}
-        onClick={onClose}
       />
 
       {/* Terminal window */}
@@ -171,8 +190,18 @@ export function TerminalOverlay({
         transition={{ duration: 0.4, ease: [0.25, 0.8, 0.25, 1] }}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-4 py-2.5 bg-[#181825] border-b border-slate-700/50" onMouseDown={(e) => e.preventDefault()}>
+        <div className="flex items-center justify-between px-3 py-2.5 bg-[#181825] border-b border-slate-700/50" onMouseDown={(e) => e.preventDefault()}>
           <div className="flex items-center gap-3">
+            {/* Back arrow — return to home */}
+            <button
+              onClick={onClose}
+              title="Back to home (⌘←)"
+              className="p-1 -ml-1 rounded-md text-slate-400 hover:text-slate-200 hover:bg-slate-700/50 transition-colors"
+            >
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M10 12L6 8L10 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+              </svg>
+            </button>
             <StatusDot status={activeSession.status} size={8} />
             <span className="text-sm font-medium text-slate-200">
               {activeSession.name}
@@ -194,44 +223,14 @@ export function TerminalOverlay({
               </button>
             )}
 
-            <div className="w-px h-4 bg-slate-700/50 mx-1" />
-
-            {/* Restart */}
-            <button
-              onClick={() => onRestart(activeTabId)}
-              title="Restart session"
-              className="px-2.5 py-1 rounded-md text-xs text-slate-400 hover:text-slate-200 hover:bg-slate-700/50 transition-colors"
-            >
-              Restart
-            </button>
-
-            {/* End / Start toggle */}
-            {isStopped ? (
-              <button
-                onClick={() => onRestart(activeTabId)}
-                title="Start session"
-                className="px-2.5 py-1 rounded-md text-xs text-green-400 hover:text-green-300 hover:bg-green-900/30 transition-colors"
-              >
-                Start
-              </button>
-            ) : (
-              <button
-                onClick={() => onEnd(activeTabId)}
-                title="End session"
-                className="px-2.5 py-1 rounded-md text-xs text-red-400 hover:text-red-300 hover:bg-red-900/30 transition-colors"
-              >
-                End
-              </button>
-            )}
-
-            {/* More menu */}
+            {/* Actions menu */}
             <div className="relative">
               <button
                 onClick={() => setShowMenu((v) => !v)}
                 className="px-2 py-1 rounded-md text-slate-500 hover:text-slate-300 hover:bg-slate-700/50 transition-colors text-sm"
-                title="More actions"
+                title="Session actions"
               >
-                ...
+                ⋯
               </button>
               <AnimatePresence>
                 {showMenu && (
@@ -240,30 +239,46 @@ export function TerminalOverlay({
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -4 }}
                   transition={{ duration: 0.2, ease: [0.25, 0.8, 0.25, 1] }}
-                  className="absolute right-0 top-full mt-1 min-w-[140px] rounded-lg bg-[#313244] border border-slate-600/50 shadow-xl py-1 z-10">
+                  className="absolute right-0 top-full mt-1 min-w-[180px] rounded-lg bg-[#313244] border border-slate-600/50 shadow-xl py-1 z-10"
+                >
+                  {/* Safe actions */}
                   <button
                     onClick={() => {
                       setShowMenu(false);
-                      onRestart(activeTabId);
+                      onRestart(session.id);
                     }}
-                    className="w-full text-left px-3 py-1.5 text-xs text-slate-300 hover:bg-slate-600/50 transition-colors"
+                    className="w-full text-left px-3 py-1.5 text-xs text-slate-300 hover:bg-slate-600/50 transition-colors flex items-center justify-between"
                   >
-                    Restart
+                    <span>Restart</span>
+                    <span className="text-[10px] text-slate-500">⌘R</span>
                   </button>
                   <button
                     onClick={() => {
                       setShowMenu(false);
-                      onEnd(activeTabId);
+                      onPark(session.id);
                     }}
-                    className="w-full text-left px-3 py-1.5 text-xs text-slate-300 hover:bg-slate-600/50 transition-colors"
+                    className="w-full text-left px-3 py-1.5 text-xs text-slate-300 hover:bg-slate-600/50 transition-colors flex items-center justify-between"
                   >
-                    End Session
+                    <span>Park</span>
+                    <span className="text-[10px] text-slate-500">⌘P</span>
+                  </button>
+                  <div className="border-t border-slate-600/50 my-1" />
+                  {/* Dangerous actions */}
+                  <button
+                    onClick={() => {
+                      setShowMenu(false);
+                      onEnd(session.id);
+                    }}
+                    className="w-full text-left px-3 py-1.5 text-xs text-slate-300 hover:bg-slate-600/50 transition-colors flex items-center justify-between"
+                  >
+                    <span>End Session</span>
+                    <span className="text-[10px] text-slate-500">⌘⇧E</span>
                   </button>
                   <div className="border-t border-slate-600/50 my-1" />
                   <button
                     onClick={() => {
                       setShowMenu(false);
-                      onRemove(activeTabId);
+                      onRemove(session.id);
                     }}
                     className="w-full text-left px-3 py-1.5 text-xs text-red-400 hover:bg-red-900/30 transition-colors"
                   >
@@ -273,15 +288,6 @@ export function TerminalOverlay({
               )}
               </AnimatePresence>
             </div>
-
-            {/* Close overlay */}
-            <button
-              onClick={onClose}
-              title="Close overlay (session keeps running)"
-              className="px-2.5 py-1 rounded-md text-xs text-slate-400 hover:text-slate-200 hover:bg-slate-700/50 transition-colors ml-1"
-            >
-              Close
-            </button>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Replace `Close`/`End`/`Restart` header buttons with `←` back arrow + single `⋯` actions menu
- Remove double-Escape close and backdrop click close to prevent accidental session loss
- Add Park to overlay menu (was only in right-click context menu)
- Add keyboard shortcuts: `⌘←`/`⌘Backspace` (back), `⌘R` (restart), `⌘P` (park), `⌘⇧E` (end)
- Align right-click context menu with same grouping, dividers, and shortcut hints

Closes #9

## Test plan
- [ ] Open a session → header shows `← [dot] Name path [+ Terminal] [⋯]`
- [ ] Click `←` → returns to home, session keeps running
- [ ] Press Escape → nothing happens (terminal keeps focus)
- [ ] Press `⌘R` → session restarts
- [ ] Press `⌘P` → session parks, returns to home
- [ ] Open `⋯` menu → shows Restart, Park, divider, End Session, divider, Remove (red)
- [ ] Click End Session → PTY killed, returns to home
- [ ] Click backdrop → nothing (no accidental close)
- [ ] Right-click session card → same actions with shortcuts and dividers

🤖 Generated with [Claude Code](https://claude.com/claude-code)