### PR TITLE
feat: session timeline, hook fix, update checker (v0.2.7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextdialog",
   "private": true,
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nextdialog"
-version = "0.2.6"
+version = "0.2.7"
 description = "Multi-session Claude Code terminal manager"
 authors = ["Brian Cline"]
 edition = "2021"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -15,6 +15,7 @@ use crate::session::types::{SessionType, SessionTypeManager};
 use crate::intelligence::IntelligenceManager;
 use crate::settings::{Settings, SettingsManager};
 use crate::telemetry::TelemetryClient;
+use crate::timeline::ledger::{TimelineEntry, TimelineLedger};
 
 // ── Session CRUD ──
 
@@ -46,10 +47,11 @@ pub fn create_session(
 pub fn remove_session(
     manager: State<'_, SessionManager>,
     hook_manager: State<'_, HookManager>,
+    ledger: State<'_, TimelineLedger>,
     id: String,
 ) -> Result<(), String> {
-    // Teardown hooks before removing — no-op if hooks aren't active
     hook_manager.teardown_session(&id);
+    ledger.clear(&id);
     manager.remove(&id)
 }
 
@@ -472,4 +474,40 @@ pub fn get_session_annotation(
     id: String,
 ) -> Option<String> {
     intelligence.get_annotation(&id)
+}
+
+// ── Timeline ──
+
+#[tauri::command]
+pub fn get_timeline_entries(
+    ledger: State<'_, TimelineLedger>,
+    id: String,
+    count: Option<usize>,
+) -> Vec<TimelineEntry> {
+    ledger.read_last(&id, count.unwrap_or(50))
+}
+
+#[tauri::command]
+pub fn catch_me_up(
+    ledger: State<'_, TimelineLedger>,
+    intelligence: State<'_, IntelligenceManager>,
+    settings_manager: State<'_, SettingsManager>,
+    id: String,
+) -> Result<String, String> {
+    let entries = ledger.read_last(&id, 20);
+    if entries.is_empty() {
+        return Ok("No activity recorded yet for this session.".to_string());
+    }
+
+    let entries_text = entries
+        .iter()
+        .map(|e| {
+            let time = e.timestamp.split('T').next_back().unwrap_or(&e.timestamp);
+            let time_short = &time[..std::cmp::min(8, time.len())];
+            format!("[{}] {}", time_short, e.summary)
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    intelligence.summarize_sync(&settings_manager, &entries_text)
 }

--- a/src-tauri/src/hooks/config.rs
+++ b/src-tauri/src/hooks/config.rs
@@ -63,17 +63,8 @@ pub fn inject_hook_config(working_dir: &str, port: u16) -> Result<(), String> {
             .as_array_mut()
             .ok_or(format!("{event_type} is not an array"))?;
 
-        // Remove any existing nextDialog-managed entries
-        matchers_arr.retain(|matcher| {
-            let hooks = matcher.get("hooks").and_then(|h| h.as_array());
-            if let Some(hooks) = hooks {
-                !hooks
-                    .iter()
-                    .any(|h| h.get("_nextdialog_managed").and_then(|v| v.as_bool()) == Some(true))
-            } else {
-                true
-            }
-        });
+        // Remove any existing entries managed by THIS port (not other sessions)
+        matchers_arr.retain(|matcher| !is_managed_by_port(matcher, port));
 
         // Add our managed entry
         matchers_arr.push(managed_matcher);
@@ -89,7 +80,9 @@ pub fn inject_hook_config(working_dir: &str, port: u16) -> Result<(), String> {
 }
 
 /// Remove nextDialog-managed hook entries from `.claude/settings.local.json`.
-pub fn remove_hook_config(working_dir: &str) -> Result<(), String> {
+/// If `port` is Some, only removes entries for that specific port (normal teardown).
+/// If `port` is None, removes ALL managed entries (crash recovery at startup).
+pub fn remove_hook_config(working_dir: &str, port: Option<u16>) -> Result<(), String> {
     let settings_path = claude_settings_path(working_dir);
 
     if !settings_path.exists() {
@@ -106,16 +99,9 @@ pub fn remove_hook_config(working_dir: &str) -> Result<(), String> {
         if let Some(hooks_map) = hooks_obj.as_object_mut() {
             for (_event_type, matchers) in hooks_map.iter_mut() {
                 if let Some(arr) = matchers.as_array_mut() {
-                    arr.retain(|matcher| {
-                        let hooks = matcher.get("hooks").and_then(|h| h.as_array());
-                        if let Some(hooks) = hooks {
-                            !hooks.iter().any(|h| {
-                                h.get("_nextdialog_managed").and_then(|v| v.as_bool())
-                                    == Some(true)
-                            })
-                        } else {
-                            true
-                        }
+                    arr.retain(|matcher| match port {
+                        Some(p) => !is_managed_by_port(matcher, p),
+                        None => !is_managed(matcher),
                     });
                 }
             }
@@ -143,6 +129,41 @@ pub fn remove_hook_config(working_dir: &str) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+/// Check if a matcher has a managed hook targeting a specific port.
+fn is_managed_by_port(matcher: &serde_json::Value, port: u16) -> bool {
+    let prefix = format!("http://127.0.0.1:{port}/hook/");
+    matcher
+        .get("hooks")
+        .and_then(|h| h.as_array())
+        .map(|hooks| {
+            hooks.iter().any(|h| {
+                h.get("_nextdialog_managed")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false)
+                    && h.get("url")
+                        .and_then(|u| u.as_str())
+                        .map(|u| u.starts_with(&prefix))
+                        .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false)
+}
+
+/// Check if a matcher has any managed hook (any port). Used for crash recovery.
+fn is_managed(matcher: &serde_json::Value) -> bool {
+    matcher
+        .get("hooks")
+        .and_then(|h| h.as_array())
+        .map(|hooks| {
+            hooks.iter().any(|h| {
+                h.get("_nextdialog_managed")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false)
 }
 
 fn claude_settings_path(working_dir: &str) -> PathBuf {
@@ -214,7 +235,7 @@ mod tests {
         let dir = tmp.path().to_str().unwrap();
 
         inject_hook_config(dir, 7432).unwrap();
-        remove_hook_config(dir).unwrap();
+        remove_hook_config(dir, Some(7432)).unwrap();
 
         let path = claude_settings_path(dir);
         // File should be removed since it was entirely managed
@@ -245,11 +266,103 @@ mod tests {
             );
         fs::write(&path, serde_json::to_string_pretty(&data).unwrap()).unwrap();
 
-        remove_hook_config(dir).unwrap();
+        remove_hook_config(dir, Some(7432)).unwrap();
 
         let data: serde_json::Value =
             serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
         let post_tool = data["hooks"]["PostToolUse"].as_array().unwrap();
         assert_eq!(post_tool.len(), 1); // Only user hook remains
+    }
+
+    #[test]
+    fn two_sessions_coexist_in_same_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_str().unwrap();
+
+        inject_hook_config(dir, 7432).unwrap();
+        inject_hook_config(dir, 7433).unwrap();
+
+        let path = claude_settings_path(dir);
+        let data: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let post_tool = data["hooks"]["PostToolUse"].as_array().unwrap();
+        assert_eq!(post_tool.len(), 2);
+
+        let urls: Vec<&str> = post_tool
+            .iter()
+            .map(|m| m["hooks"][0]["url"].as_str().unwrap())
+            .collect();
+        assert!(urls.contains(&"http://127.0.0.1:7432/hook/PostToolUse"));
+        assert!(urls.contains(&"http://127.0.0.1:7433/hook/PostToolUse"));
+    }
+
+    #[test]
+    fn remove_one_session_preserves_other() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_str().unwrap();
+
+        inject_hook_config(dir, 7432).unwrap();
+        inject_hook_config(dir, 7433).unwrap();
+        remove_hook_config(dir, Some(7432)).unwrap();
+
+        let path = claude_settings_path(dir);
+        let data: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let post_tool = data["hooks"]["PostToolUse"].as_array().unwrap();
+        assert_eq!(post_tool.len(), 1);
+        let url = post_tool[0]["hooks"][0]["url"].as_str().unwrap();
+        assert_eq!(url, "http://127.0.0.1:7433/hook/PostToolUse");
+    }
+
+    #[test]
+    fn remove_all_managed_for_crash_recovery() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_str().unwrap();
+
+        inject_hook_config(dir, 7432).unwrap();
+        inject_hook_config(dir, 7433).unwrap();
+        remove_hook_config(dir, None).unwrap();
+
+        let path = claude_settings_path(dir);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn three_sessions_teardown_in_any_order() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_str().unwrap();
+
+        inject_hook_config(dir, 7432).unwrap();
+        inject_hook_config(dir, 7433).unwrap();
+        inject_hook_config(dir, 7434).unwrap();
+
+        // Tear down middle one first
+        remove_hook_config(dir, Some(7433)).unwrap();
+
+        let path = claude_settings_path(dir);
+        let data: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let post_tool = data["hooks"]["PostToolUse"].as_array().unwrap();
+        assert_eq!(post_tool.len(), 2);
+
+        // Tear down remaining in reverse order
+        remove_hook_config(dir, Some(7434)).unwrap();
+        remove_hook_config(dir, Some(7432)).unwrap();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn reinject_same_port_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_str().unwrap();
+
+        inject_hook_config(dir, 7432).unwrap();
+        inject_hook_config(dir, 7432).unwrap();
+
+        let path = claude_settings_path(dir);
+        let data: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let post_tool = data["hooks"]["PostToolUse"].as_array().unwrap();
+        assert_eq!(post_tool.len(), 1);
     }
 }

--- a/src-tauri/src/hooks/manager.rs
+++ b/src-tauri/src/hooks/manager.rs
@@ -64,7 +64,7 @@ impl HookManager {
             }
             Err(e) => {
                 eprintln!("[hooks] Failed to start server for session {session_id}: {e}");
-                let _ = config::remove_hook_config(working_dir);
+                let _ = config::remove_hook_config(working_dir, Some(port));
                 self.port_pool.release(port);
                 Ok(false)
             }
@@ -78,7 +78,7 @@ impl HookManager {
         if let Some(mut session) = removed {
             let port = session.server.port();
             session.server.stop_and_wait();
-            if let Err(e) = config::remove_hook_config(&session.working_dir) {
+            if let Err(e) = config::remove_hook_config(&session.working_dir, Some(port)) {
                 eprintln!("[hooks] Failed to clean config for session {session_id}: {e}");
             }
             self.port_pool.release(port);
@@ -90,7 +90,7 @@ impl HookManager {
     /// Runs against the filesystem only — no active servers to stop.
     pub fn cleanup_stale_hooks(working_dirs: &[String]) {
         for dir in working_dirs {
-            match config::remove_hook_config(dir) {
+            match config::remove_hook_config(dir, None) {
                 Ok(()) => eprintln!("[hooks] Cleaned stale hooks from {dir}"),
                 Err(e) => eprintln!("[hooks] Failed to clean stale hooks from {dir}: {e}"),
             }

--- a/src-tauri/src/hooks/processor.rs
+++ b/src-tauri/src/hooks/processor.rs
@@ -4,23 +4,46 @@ use tauri::{AppHandle, Emitter, Manager};
 use super::payloads::{HookEvent, HookPayload};
 use crate::session::file_tracker::FileTracker;
 use crate::status::detector::HookStatus;
+use crate::timeline::ledger::{TimelineEntry, TimelineLedger};
 
 /// Process a parsed hook payload and emit appropriate Tauri events.
 pub fn process(session_id: &str, payload: HookPayload, app_handle: &AppHandle) {
-    match payload.event() {
+    let timeline_entry = match payload.event() {
         HookEvent::PostToolUse => process_tool_use(session_id, &payload, app_handle),
         HookEvent::Stop => {
             let _ = app_handle.emit(
                 &format!("session-status-{session_id}"),
                 "idle",
             );
-            // Signal the detector that hooks confirmed idle
-            if let Some(pool) = app_handle.try_state::<crate::pty::pool::PtyPool>() {
+            // Capture terminal preview lines for a meaningful summary
+            let summary = if let Some(pool) = app_handle.try_state::<crate::pty::pool::PtyPool>() {
                 pool.set_hook_status(session_id, HookStatus::Idle);
-            }
+                let lines = pool.get_preview(session_id);
+                if lines.is_empty() {
+                    "Went idle".to_string()
+                } else {
+                    // Take last 2-3 lines — the most recent context
+                    let recent: Vec<&str> = lines.iter()
+                        .rev()
+                        .take(3)
+                        .rev()
+                        .map(|s| s.as_str())
+                        .collect();
+                    let text: String = recent.join(" — ")
+                        .chars()
+                        .take(200)
+                        .collect();
+                    if text.is_empty() { "Went idle".to_string() } else { text }
+                }
+            } else {
+                "Went idle".to_string()
+            };
+            Some(
+                TimelineEntry::new("status", &summary)
+                    .with_details(serde_json::json!({"source": "preview_lines"})),
+            )
         }
         HookEvent::Notification => {
-            // Emit waiting status immediately (faster than regex detection)
             let _ = app_handle.emit(
                 &format!("session-status-{session_id}"),
                 "waiting",
@@ -28,47 +51,81 @@ pub fn process(session_id: &str, payload: HookPayload, app_handle: &AppHandle) {
             if let Some(pool) = app_handle.try_state::<crate::pty::pool::PtyPool>() {
                 pool.set_hook_status(session_id, HookStatus::Waiting);
             }
-            // Emit notification text for card display
             if let Some(ref msg) = payload.message {
                 let _ = app_handle.emit(
                     &format!("session-hook-notification-{session_id}"),
                     msg.clone(),
                 );
             }
+            let summary = payload
+                .message
+                .as_deref()
+                .map(|m| if m.len() > 80 { &m[..80] } else { m })
+                .unwrap_or("Waiting for input")
+                .to_string();
+            Some(TimelineEntry::new("notification", &summary))
         }
         HookEvent::SessionStart => {
             let _ = app_handle.emit(
                 &format!("session-hook-lifecycle-{session_id}"),
                 "started",
             );
+            Some(TimelineEntry::new("lifecycle", "Session started"))
         }
         HookEvent::SessionEnd => {
             let _ = app_handle.emit(
                 &format!("session-hook-lifecycle-{session_id}"),
                 "ended",
             );
+            Some(TimelineEntry::new("lifecycle", "Session ended"))
         }
         HookEvent::PostCompact => {
-            // Log for debugging; payload fields not fully documented
             if let (Some(before), Some(after)) = (payload.tokens_before, payload.tokens_after) {
                 eprintln!(
                     "[hooks] PostCompact session={session_id}: {before} -> {after} tokens"
                 );
+                Some(
+                    TimelineEntry::new(
+                        "compact",
+                        &format!("Context compacted: {before} → {after} tokens"),
+                    )
+                    .with_details(serde_json::json!({
+                        "tokens_before": before,
+                        "tokens_after": after,
+                    })),
+                )
+            } else {
+                None
             }
         }
         HookEvent::Unknown(ref name) => {
             eprintln!("[hooks] Unknown hook event for session {session_id}: {name}");
+            None
+        }
+    };
+
+    // Persist to timeline ledger and emit real-time event
+    if let Some(entry) = timeline_entry {
+        if let Some(ledger) = app_handle.try_state::<TimelineLedger>() {
+            ledger.append(session_id, &entry);
+            let _ = app_handle.emit(
+                &format!("session-timeline-{session_id}"),
+                &entry,
+            );
         }
     }
 }
 
-fn process_tool_use(session_id: &str, payload: &HookPayload, app_handle: &AppHandle) {
+fn process_tool_use(
+    session_id: &str,
+    payload: &HookPayload,
+    app_handle: &AppHandle,
+) -> Option<TimelineEntry> {
     let tool = payload.tool_name.as_deref().unwrap_or("");
 
     match tool {
         "Write" | "Edit" | "NotebookEdit" => {
             if let Some(path) = payload.file_path() {
-                // Instant file conflict detection via hook (augments 10s git polling)
                 if let Some(tracker) = app_handle.try_state::<FileTracker>() {
                     tracker.record_write(session_id, &path);
                 }
@@ -76,6 +133,16 @@ fn process_tool_use(session_id: &str, payload: &HookPayload, app_handle: &AppHan
                     &format!("session-hook-file-write-{session_id}"),
                     &path,
                 );
+                let basename = std::path::Path::new(&path)
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or(&path);
+                Some(
+                    TimelineEntry::new("file_write", &format!("Edited {basename}"))
+                        .with_details(serde_json::json!({"path": path})),
+                )
+            } else {
+                None
             }
         }
         "Bash" => {
@@ -88,15 +155,184 @@ fn process_tool_use(session_id: &str, payload: &HookPayload, app_handle: &AppHan
                         "activity": activity,
                     }),
                 );
+                let summary = match activity {
+                    "test" => format!("Ran tests: {}", truncate_cmd(&cmd, 40)),
+                    "build" => format!("Built: {}", truncate_cmd(&cmd, 40)),
+                    "deploy" => format!("Deployed: {}", truncate_cmd(&cmd, 40)),
+                    "lint" => format!("Lint: {}", truncate_cmd(&cmd, 40)),
+                    _ => format!("$ {}", truncate_cmd(&cmd, 50)),
+                };
+                Some(
+                    TimelineEntry::new("bash", &summary)
+                        .with_details(serde_json::json!({
+                            "command": cmd,
+                            "activity": activity,
+                        })),
+                )
+            } else {
+                None
             }
         }
         _ => {
-            // Emit generic tool use event
             let _ = app_handle.emit(
                 &format!("session-hook-tool-{session_id}"),
                 tool,
             );
+            // Skip noisy internal tools that don't add context
+            if matches!(tool, "ToolSearch" | "TaskCreate" | "TaskUpdate" | "TaskGet" | "TaskList" | "TaskStop" | "TaskOutput") {
+                None
+            } else if !tool.is_empty() {
+                let summary = describe_tool(tool, payload.tool_input.as_ref(), session_id, app_handle);
+                Some(
+                    TimelineEntry::new("tool", &summary)
+                        .with_details(serde_json::json!({"tool": tool})),
+                )
+            } else {
+                None
+            }
         }
+    }
+}
+
+/// Generate a descriptive summary for a tool use based on tool_input data.
+fn describe_tool(
+    tool: &str,
+    input: Option<&serde_json::Value>,
+    session_id: &str,
+    app_handle: &AppHandle,
+) -> String {
+    let input = match input {
+        Some(v) => v,
+        None => return format!("Used {tool}"),
+    };
+
+    match tool {
+        "Read" => {
+            let path = input
+                .get("file_path")
+                .or_else(|| input.get("path"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if path.is_empty() {
+                "Read file".to_string()
+            } else {
+                let basename = std::path::Path::new(path)
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or(path);
+                format!("Read {basename}")
+            }
+        }
+        "Grep" => {
+            let pattern = input.get("pattern").and_then(|v| v.as_str()).unwrap_or("");
+            if pattern.is_empty() {
+                "Searched code".to_string()
+            } else {
+                format!("Searched for '{}'", truncate_str(pattern, 30))
+            }
+        }
+        "Glob" => {
+            let pattern = input.get("pattern").and_then(|v| v.as_str()).unwrap_or("");
+            if pattern.is_empty() {
+                "Found files".to_string()
+            } else {
+                format!("Found files: {}", truncate_str(pattern, 30))
+            }
+        }
+        "Agent" => {
+            let desc = input
+                .get("description")
+                .and_then(|v| v.as_str())
+                .or_else(|| input.get("prompt").and_then(|v| v.as_str()))
+                .unwrap_or("");
+            if desc.is_empty() {
+                "Ran agent".to_string()
+            } else {
+                truncate_str(desc, 60).to_string()
+            }
+        }
+        "EnterPlanMode" => "Entered planning mode".to_string(),
+        "ExitPlanMode" => {
+            // Try to read the terminal preview for plan context
+            if let Some(pool) = app_handle.try_state::<crate::pty::pool::PtyPool>() {
+                let lines = pool.get_preview(session_id);
+                if !lines.is_empty() {
+                    let context = lines.join(" ");
+                    format!("Plan ready: {}", truncate_str(&context, 80))
+                } else {
+                    "Plan ready for review".to_string()
+                }
+            } else {
+                "Plan ready for review".to_string()
+            }
+        }
+        "WebSearch" => {
+            let query = input.get("query").and_then(|v| v.as_str()).unwrap_or("");
+            if query.is_empty() {
+                "Web search".to_string()
+            } else {
+                format!("Searched web: {}", truncate_str(query, 40))
+            }
+        }
+        "WebFetch" => {
+            let url = input.get("url").and_then(|v| v.as_str()).unwrap_or("");
+            if url.is_empty() {
+                "Fetched URL".to_string()
+            } else {
+                format!("Fetched {}", truncate_str(url, 40))
+            }
+        }
+        "ToolSearch" => {
+            let query = input.get("query").and_then(|v| v.as_str()).unwrap_or("");
+            if query.is_empty() {
+                "Loaded tools".to_string()
+            } else {
+                format!("Loaded: {}", truncate_str(query, 30))
+            }
+        }
+        "Skill" => {
+            let skill = input.get("skill").and_then(|v| v.as_str()).unwrap_or("");
+            if skill.is_empty() {
+                "Used skill".to_string()
+            } else {
+                format!("Ran /{skill}")
+            }
+        }
+        "AskUserQuestion" => {
+            // The user is being asked a question — capture what it's about
+            if let Some(pool) = app_handle.try_state::<crate::pty::pool::PtyPool>() {
+                let lines = pool.get_preview(session_id);
+                if !lines.is_empty() {
+                    let context = lines.last().unwrap_or(&lines[0]).clone();
+                    format!("Asked: {}", truncate_str(&context, 60))
+                } else {
+                    "Asked a question".to_string()
+                }
+            } else {
+                "Asked a question".to_string()
+            }
+        }
+        _ => format!("Used {tool}"),
+    }
+}
+
+/// Truncate a string to max length, appending "…" if truncated.
+fn truncate_str(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        s
+    } else {
+        &s[..max]
+    }
+}
+
+/// Truncate a command string, taking just the first meaningful portion.
+fn truncate_cmd(cmd: &str, max: usize) -> String {
+    // Take first line only
+    let first_line = cmd.lines().next().unwrap_or(cmd);
+    if first_line.len() <= max {
+        first_line.to_string()
+    } else {
+        format!("{}…", &first_line[..max])
     }
 }
 

--- a/src-tauri/src/intelligence/mod.rs
+++ b/src-tauri/src/intelligence/mod.rs
@@ -81,7 +81,7 @@ impl IntelligenceManager {
         let prompt_text = preview_lines.join("\n");
 
         std::thread::spawn(move || {
-            let result = provider::call_llm(&client, &provider, &api_key, &api_url, &prompt_text);
+            let result = provider::call_annotation(&client, &provider, &api_key, &api_url, &prompt_text);
 
             match result {
                 Ok(text) => {
@@ -106,5 +106,32 @@ impl IntelligenceManager {
 
     pub fn clear_annotation(&self, id: &str) {
         self.annotations.lock().unwrap().remove(id);
+    }
+
+    /// Synchronously summarize timeline entries for "catch me up" feature.
+    /// No cooldown or inflight guard — this is user-initiated.
+    pub fn summarize_sync(
+        &self,
+        settings_manager: &SettingsManager,
+        entries_text: &str,
+    ) -> Result<String, String> {
+        let settings = settings_manager.get();
+
+        if !settings.intelligence_enabled || settings.intelligence_api_key.is_empty() {
+            return Err("Intelligence is not configured. Enable it in Settings to use Catch Me Up.".to_string());
+        }
+
+        let system = "You are summarizing what happened in a coding session. Given recent actions, provide a 2-3 sentence catch-me-up summary. Be specific about what was worked on. Focus on outcomes, not process. Reply with only the summary.";
+
+        provider::call_llm(
+            &self.client,
+            &settings.intelligence_provider,
+            &settings.intelligence_api_key,
+            &settings.intelligence_api_url,
+            system,
+            entries_text,
+            150,
+        )
+        .map(|s| s.trim().to_string())
     }
 }

--- a/src-tauri/src/intelligence/provider.rs
+++ b/src-tauri/src/intelligence/provider.rs
@@ -1,19 +1,34 @@
 use serde_json::json;
 
-pub fn call_llm(
+const ANNOTATION_SYSTEM_PROMPT: &str =
+    "Summarize what this terminal session just did in 5-10 words. Be specific. Reply with only the summary.";
+
+/// Call LLM for a short annotation (5-10 word summary).
+pub fn call_annotation(
     client: &reqwest::blocking::Client,
     provider: &str,
     api_key: &str,
     api_url: &str,
     prompt: &str,
 ) -> Result<String, String> {
-    let system = "Summarize what this terminal session just did in 5-10 words. Be specific. Reply with only the summary.";
+    call_llm(client, provider, api_key, api_url, ANNOTATION_SYSTEM_PROMPT, prompt, 30)
+}
 
+/// Call LLM with custom system prompt and max tokens.
+pub fn call_llm(
+    client: &reqwest::blocking::Client,
+    provider: &str,
+    api_key: &str,
+    api_url: &str,
+    system_prompt: &str,
+    prompt: &str,
+    max_tokens: u32,
+) -> Result<String, String> {
     match provider {
-        "anthropic" => call_anthropic(client, api_key, system, prompt),
-        "openai" => call_openai(client, api_key, system, prompt),
-        "gemini" => call_gemini(client, api_key, system, prompt),
-        "ollama" => call_ollama(client, api_url, system, prompt),
+        "anthropic" => call_anthropic(client, api_key, system_prompt, prompt, max_tokens),
+        "openai" => call_openai(client, api_key, system_prompt, prompt, max_tokens),
+        "gemini" => call_gemini(client, api_key, system_prompt, prompt, max_tokens),
+        "ollama" => call_ollama(client, api_url, system_prompt, prompt, max_tokens),
         _ => Err(format!("Unknown provider: {provider}")),
     }
 }
@@ -23,10 +38,11 @@ fn call_anthropic(
     api_key: &str,
     system: &str,
     prompt: &str,
+    max_tokens: u32,
 ) -> Result<String, String> {
     let body = json!({
         "model": "claude-haiku-4-5-20251001",
-        "max_tokens": 30,
+        "max_tokens": max_tokens,
         "system": system,
         "messages": [{"role": "user", "content": prompt}]
     });
@@ -53,10 +69,11 @@ fn call_openai(
     api_key: &str,
     system: &str,
     prompt: &str,
+    max_tokens: u32,
 ) -> Result<String, String> {
     let body = json!({
         "model": "gpt-4o-mini",
-        "max_tokens": 30,
+        "max_tokens": max_tokens,
         "messages": [
             {"role": "system", "content": system},
             {"role": "user", "content": prompt}
@@ -84,11 +101,12 @@ fn call_gemini(
     api_key: &str,
     system: &str,
     prompt: &str,
+    max_tokens: u32,
 ) -> Result<String, String> {
     let body = json!({
         "system_instruction": {"parts": [{"text": system}]},
         "contents": [{"parts": [{"text": prompt}]}],
-        "generationConfig": {"maxOutputTokens": 30}
+        "generationConfig": {"maxOutputTokens": max_tokens}
     });
 
     let url = format!(
@@ -115,6 +133,7 @@ fn call_ollama(
     api_url: &str,
     system: &str,
     prompt: &str,
+    max_tokens: u32,
 ) -> Result<String, String> {
     let base = if api_url.is_empty() {
         "http://localhost:11434"
@@ -129,7 +148,7 @@ fn call_ollama(
             {"role": "user", "content": prompt}
         ],
         "stream": false,
-        "options": {"num_predict": 30}
+        "options": {"num_predict": max_tokens}
     });
 
     let resp = client

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod settings;
 mod intelligence;
 mod status;
 mod telemetry;
+mod timeline;
 
 use tauri::Manager;
 
@@ -18,6 +19,7 @@ use session::types::SessionTypeManager;
 use intelligence::IntelligenceManager;
 use settings::SettingsManager;
 use telemetry::TelemetryClient;
+use timeline::ledger::TimelineLedger;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -39,6 +41,7 @@ pub fn run() {
         .manage(IntelligenceManager::new())
         .manage(HookManager::new())
         .manage(telemetry_client)
+        .manage(TimelineLedger::new())
         .setup(|app| {
             // Clean stale hooks from any previous crash/force-quit
             let sessions = app.state::<SessionManager>();
@@ -98,6 +101,8 @@ pub fn run() {
             commands::import_background_image,
             commands::reset_background,
             commands::get_background_image_data,
+            commands::get_timeline_entries,
+            commands::catch_me_up,
         ])
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::Destroyed = event {

--- a/src-tauri/src/pty/pool.rs
+++ b/src-tauri/src/pty/pool.rs
@@ -254,6 +254,22 @@ impl PtyPool {
                                     pv.pop_front();
                                 }
                                 pv.push_back(capped.to_string());
+
+                                // Detect user input prompts (❯ or › followed by text)
+                                let prompt_text = detect_user_prompt(capped);
+                                if let Some(input) = prompt_text {
+                                    if let Some(ledger) = handle.try_state::<crate::timeline::ledger::TimelineLedger>() {
+                                        let entry = crate::timeline::ledger::TimelineEntry::new(
+                                            "user_input",
+                                            &input,
+                                        );
+                                        ledger.append(&session_id, &entry);
+                                        let _ = handle.emit(
+                                            &format!("session-timeline-{session_id}"),
+                                            &entry,
+                                        );
+                                    }
+                                }
                             }
                         }
 
@@ -493,6 +509,33 @@ impl PtyPool {
         };
 
         self.spawn_inner(id, cmd, rows, cols, app_handle, patterns)
+    }
+}
+
+/// Detect user input at the Claude Code prompt.
+/// Claude Code shows user input as "❯ text" or "› text" or "> text" after submission.
+fn detect_user_prompt(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+
+    // Match Claude Code prompt patterns: ❯, ›, or >  followed by user text
+    let text = if let Some(rest) = trimmed.strip_prefix('❯') {
+        Some(rest.trim())
+    } else if let Some(rest) = trimmed.strip_prefix('›') {
+        Some(rest.trim())
+    } else if let Some(rest) = trimmed.strip_prefix("> ") {
+        // Only "> " with space to avoid matching markdown blockquotes
+        Some(rest.trim())
+    } else {
+        None
+    };
+
+    match text {
+        Some(t) if t.len() >= 5 => {
+            // Cap at 200 chars
+            let capped = if t.len() > 200 { &t[..200] } else { t };
+            Some(capped.to_string())
+        }
+        _ => None,
     }
 }
 

--- a/src-tauri/src/pty/pool.rs
+++ b/src-tauri/src/pty/pool.rs
@@ -204,8 +204,20 @@ impl PtyPool {
                             let stripped = strip_ansi_escapes::strip(&buf[..n]);
                             let text = String::from_utf8_lossy(&stripped);
                             let mut pv = preview.lock().unwrap();
+                            // Split on \n, then handle \r within each line
+                            // (terminals use \r to overwrite — keep only text after last \r)
                             for line in text.split('\n') {
-                                let trimmed = line.trim();
+                                // Handle carriage returns: keep only the last segment
+                                let line = if line.contains('\r') {
+                                    line.rsplit('\r').next().unwrap_or(line)
+                                } else {
+                                    line
+                                };
+                                // Strip remaining control characters
+                                let cleaned: String = line.chars()
+                                    .filter(|c| !c.is_control() || *c == ' ')
+                                    .collect();
+                                let trimmed = cleaned.trim();
                                 if trimmed.is_empty() {
                                     continue;
                                 }
@@ -217,12 +229,16 @@ impl PtyPool {
                                 if alpha_count < 3 {
                                     continue;
                                 }
-                                // Skip Claude Code status bar lines
+                                // Skip Claude Code status bar / UI chrome lines
                                 if trimmed.starts_with("connected |")
                                     || (trimmed.starts_with("agent ")
                                         && trimmed.contains("| session ")
                                         && trimmed.contains("| tokens "))
                                 {
+                                    continue;
+                                }
+                                // Skip Claude Code spinner/progress lines
+                                if is_claude_spinner_line(trimmed) {
                                     continue;
                                 }
                                 let capped = if trimmed.len() > 200 {
@@ -478,6 +494,49 @@ impl PtyPool {
 
         self.spawn_inner(id, cmd, rows, cols, app_handle, patterns)
     }
+}
+
+/// Detect Claude Code animated spinner/progress/status lines that pollute preview.
+fn is_claude_spinner_line(line: &str) -> bool {
+    // Claude Code uses cooking-themed verbs as spinners: "Sautéed for 1m 30s", "Hashing…"
+    // Also status mode lines: "plan mode on", "bypass permissions on"
+    let lower = line.to_lowercase();
+
+    // Spinner verbs (Claude Code's animated status)
+    if lower.ends_with('…')
+        || lower.ends_with("...")
+    {
+        // "Hashing…", "Pontificating…", "Catapulting…", "Cooking…"
+        let word_count = line.split_whitespace().count();
+        if word_count <= 3 {
+            return true;
+        }
+    }
+
+    // Duration lines: "Sautéed for 1m 30s", "Cooked for 2m 10s"
+    if (lower.contains(" for ") && (lower.contains("m ") || lower.contains("s")))
+        && lower.split_whitespace().count() <= 5
+    {
+        let has_duration = lower.chars().any(|c| c.is_ascii_digit());
+        if has_duration {
+            return true;
+        }
+    }
+
+    // Mode indicator lines
+    if lower.starts_with("plan mode")
+        || lower.starts_with("bypass permissions")
+        || lower.starts_with("auto-accept")
+        || lower.contains("shift+tab to cycle")
+        || lower.contains("esc to interrupt")
+        || lower.contains("esc to cancel")
+        || lower.contains("ctrl+o to expand")
+        || lower.contains("Image in clipboard")
+    {
+        return true;
+    }
+
+    false
 }
 
 /// Translate AgentConfig fields into CLI arguments and env vars on the command.

--- a/src-tauri/src/timeline/ledger.rs
+++ b/src-tauri/src/timeline/ledger.rs
@@ -1,0 +1,237 @@
+use std::fs::{self, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimelineEntry {
+    pub timestamp: String,
+    pub event_type: String,
+    pub summary: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<serde_json::Value>,
+}
+
+impl TimelineEntry {
+    pub fn new(event_type: &str, summary: &str) -> Self {
+        Self {
+            timestamp: Utc::now().to_rfc3339(),
+            event_type: event_type.to_string(),
+            summary: summary.to_string(),
+            details: None,
+        }
+    }
+
+    pub fn with_details(mut self, details: serde_json::Value) -> Self {
+        self.details = Some(details);
+        self
+    }
+}
+
+pub struct TimelineLedger {
+    base_dir: PathBuf,
+}
+
+impl TimelineLedger {
+    pub fn new() -> Self {
+        let base_dir = dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".nextdialog")
+            .join("timelines");
+
+        if let Err(e) = fs::create_dir_all(&base_dir) {
+            eprintln!("[timeline] Failed to create timelines directory: {e}");
+        }
+
+        Self { base_dir }
+    }
+
+    /// Append a timeline entry to the session's JSONL file.
+    pub fn append(&self, session_id: &str, entry: &TimelineEntry) {
+        let path = self.session_path(session_id);
+
+        let mut line = match serde_json::to_string(entry) {
+            Ok(json) => json,
+            Err(e) => {
+                eprintln!("[timeline] Failed to serialize entry: {e}");
+                return;
+            }
+        };
+        line.push('\n');
+
+        match OpenOptions::new().create(true).append(true).open(&path) {
+            Ok(mut file) => {
+                if let Err(e) = file.write_all(line.as_bytes()) {
+                    eprintln!("[timeline] Failed to write entry: {e}");
+                }
+            }
+            Err(e) => {
+                eprintln!("[timeline] Failed to open timeline file: {e}");
+            }
+        }
+    }
+
+    /// Read the last `count` entries from a session's timeline.
+    pub fn read_last(&self, session_id: &str, count: usize) -> Vec<TimelineEntry> {
+        let path = self.session_path(session_id);
+
+        let file = match fs::File::open(&path) {
+            Ok(f) => f,
+            Err(_) => return Vec::new(),
+        };
+
+        let reader = BufReader::new(file);
+        let entries: Vec<TimelineEntry> = reader
+            .lines()
+            .filter_map(|line| {
+                line.ok()
+                    .and_then(|l| serde_json::from_str(&l).ok())
+            })
+            .collect();
+
+        let start = entries.len().saturating_sub(count);
+        entries[start..].to_vec()
+    }
+
+    /// Trim a session's timeline to keep only the last `keep` entries.
+    #[allow(dead_code)]
+    pub fn trim(&self, session_id: &str, keep: usize) {
+        let path = self.session_path(session_id);
+
+        let entries = self.read_last(session_id, keep);
+        if entries.is_empty() {
+            return;
+        }
+
+        let lines: Vec<String> = entries
+            .iter()
+            .filter_map(|e| serde_json::to_string(e).ok())
+            .collect();
+
+        if let Err(e) = fs::write(&path, lines.join("\n") + "\n") {
+            eprintln!("[timeline] Failed to trim timeline: {e}");
+        }
+    }
+
+    /// Remove a session's timeline file entirely.
+    pub fn clear(&self, session_id: &str) {
+        let path = self.session_path(session_id);
+        let _ = fs::remove_file(&path);
+    }
+
+    /// Count entries in a session's timeline (for lazy trim checks).
+    #[allow(dead_code)]
+    pub fn count(&self, session_id: &str) -> usize {
+        let path = self.session_path(session_id);
+        match fs::File::open(&path) {
+            Ok(f) => BufReader::new(f).lines().count(),
+            Err(_) => 0,
+        }
+    }
+
+    fn session_path(&self, session_id: &str) -> PathBuf {
+        self.base_dir.join(format!("{session_id}.jsonl"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_ledger() -> (tempfile::TempDir, TimelineLedger) {
+        let tmp = tempfile::tempdir().unwrap();
+        let ledger = TimelineLedger {
+            base_dir: tmp.path().to_path_buf(),
+        };
+        (tmp, ledger)
+    }
+
+    #[test]
+    fn append_and_read() {
+        let (_tmp, ledger) = test_ledger();
+
+        for i in 0..5 {
+            let entry = TimelineEntry::new("file_write", &format!("Edited file_{i}.tsx"));
+            ledger.append("s1", &entry);
+        }
+
+        let entries = ledger.read_last("s1", 3);
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].summary, "Edited file_2.tsx");
+        assert_eq!(entries[2].summary, "Edited file_4.tsx");
+    }
+
+    #[test]
+    fn read_empty_session() {
+        let (_tmp, ledger) = test_ledger();
+        let entries = ledger.read_last("nonexistent", 10);
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn trim_entries() {
+        let (_tmp, ledger) = test_ledger();
+
+        for i in 0..1500 {
+            let entry = TimelineEntry::new("bash", &format!("Command {i}"));
+            ledger.append("s1", &entry);
+        }
+
+        assert_eq!(ledger.count("s1"), 1500);
+
+        ledger.trim("s1", 1000);
+
+        assert_eq!(ledger.count("s1"), 1000);
+        let entries = ledger.read_last("s1", 1);
+        assert_eq!(entries[0].summary, "Command 1499");
+    }
+
+    #[test]
+    fn clear_removes_file() {
+        let (_tmp, ledger) = test_ledger();
+
+        let entry = TimelineEntry::new("lifecycle", "Session started");
+        ledger.append("s1", &entry);
+
+        assert!(ledger.session_path("s1").exists());
+
+        ledger.clear("s1");
+        assert!(!ledger.session_path("s1").exists());
+    }
+
+    #[test]
+    fn skip_malformed_lines() {
+        let (_tmp, ledger) = test_ledger();
+        let path = ledger.session_path("s1");
+
+        // Write a valid entry, then a corrupt line, then another valid entry
+        let entry1 = TimelineEntry::new("bash", "First");
+        let entry2 = TimelineEntry::new("bash", "Third");
+        let mut content = serde_json::to_string(&entry1).unwrap();
+        content.push('\n');
+        content.push_str("this is not json\n");
+        content.push_str(&serde_json::to_string(&entry2).unwrap());
+        content.push('\n');
+
+        fs::write(&path, content).unwrap();
+
+        let entries = ledger.read_last("s1", 10);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].summary, "First");
+        assert_eq!(entries[1].summary, "Third");
+    }
+
+    #[test]
+    fn entry_with_details() {
+        let (_tmp, ledger) = test_ledger();
+
+        let entry = TimelineEntry::new("file_write", "Edited App.tsx")
+            .with_details(serde_json::json!({"path": "/src/App.tsx"}));
+        ledger.append("s1", &entry);
+
+        let entries = ledger.read_last("s1", 1);
+        assert_eq!(entries[0].details.as_ref().unwrap()["path"], "/src/App.tsx");
+    }
+}

--- a/src-tauri/src/timeline/mod.rs
+++ b/src-tauri/src/timeline/mod.rs
@@ -1,0 +1,1 @@
+pub mod ledger;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicepage/nicepage/master/assets/tauri.conf.json",
   "productName": "NextDialog",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "identifier": "com.nextdialog.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -1,6 +1,8 @@
 import { motion } from "framer-motion";
+import { invoke } from "@tauri-apps/api/core";
 import type { Session, SessionType } from "../lib/types";
 import { SessionCard } from "./SessionCard";
+import { useUpdateCheck } from "../hooks/useUpdateCheck";
 
 interface HomeViewProps {
   sessions: Session[];
@@ -39,6 +41,7 @@ export function HomeView({
   sessionTypeMap = {},
   activeSessionId = null,
 }: HomeViewProps) {
+  const { update } = useUpdateCheck();
   const isTerminalOpen = activeSessionId !== null;
   const renderCards = (cards: Session[], startIndex: number) =>
     cards.map((session, i) => (
@@ -66,6 +69,15 @@ export function HomeView({
 
         {/* Right — actions (absolute so they don't shift the center) */}
         <div className="absolute right-6 flex items-center gap-1">
+          {update && (
+            <button
+              onClick={() => invoke("plugin:opener|open_url", { url: update.downloadUrl }).catch(() => {})}
+              className="px-2.5 py-1.5 rounded-lg text-xs text-indigo-500 hover:bg-indigo-50/50 hover:text-indigo-600 transition-colors"
+              title={`Update available: v${update.latestVersion} (current: v${update.currentVersion})`}
+            >
+              v{update.latestVersion} available
+            </button>
+          )}
           <button
             onClick={onOpenFeedback}
             className="px-2.5 py-1.5 rounded-lg text-xs text-slate-500 hover:bg-white/40 hover:text-slate-700 transition-colors"

--- a/src/components/SessionCard.tsx
+++ b/src/components/SessionCard.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { listen } from "@tauri-apps/api/event";
-import type { Session, SessionType } from "../lib/types";
+import type { Session, SessionType, TimelineEntry } from "../lib/types";
 import { StatusDot } from "./StatusDot";
 import { TokenBurnBar } from "./TokenBurnBar";
 import { SessionTypeIcon } from "./SessionTypeIcon";
@@ -34,6 +34,7 @@ export function SessionCard({
 }: SessionCardProps) {
   const [contextUsage, setContextUsage] = useState<number | null>(null);
   const [annotation, setAnnotation] = useState<string | null>(null);
+  const [lastTimelineEvent, setLastTimelineEvent] = useState<string | null>(null);
 
   const brandColor = sessionType?.color;
 
@@ -53,6 +54,17 @@ export function SessionCard({
     let cleanup: (() => void) | undefined;
     listen<string>(`session-annotation-${session.id}`, (event) => {
       setAnnotation(event.payload || null);
+    }).then((unlisten) => {
+      cleanup = unlisten;
+    });
+    return () => cleanup?.();
+  }, [session.id]);
+
+  // Listen for timeline events (for "last action" preview)
+  useEffect(() => {
+    let cleanup: (() => void) | undefined;
+    listen<TimelineEntry>(`session-timeline-${session.id}`, (event) => {
+      setLastTimelineEvent(event.payload.summary);
     }).then((unlisten) => {
       cleanup = unlisten;
     });
@@ -116,10 +128,10 @@ export function SessionCard({
         </p>
       )}
 
-      {/* Last tool use indicator */}
-      {session.lastToolUse && session.status === "working" && (
+      {/* Last timeline event */}
+      {lastTimelineEvent && (
         <p className="text-[11px] text-slate-400/70 font-mono truncate mt-1">
-          {session.lastToolUse}
+          {lastTimelineEvent}
         </p>
       )}
 

--- a/src/components/SessionTimeline.tsx
+++ b/src/components/SessionTimeline.tsx
@@ -1,0 +1,140 @@
+import { motion } from "framer-motion";
+import { useTimelineEvents } from "../hooks/useTimelineEvents";
+import type { GroupedTimelineEntry } from "../lib/types";
+
+interface SessionTimelineProps {
+  sessionId: string;
+  isOpen: boolean;
+  onDismiss: () => void;
+}
+
+const DOT_COLORS: Record<string, string> = {
+  file_write: "bg-[#E8845C]",
+  bash: "bg-[#5BA7A7]",
+  tool: "bg-slate-400",
+  notification: "bg-amber-400",
+  status: "bg-slate-500",
+  lifecycle: "bg-[#8B3A62]",
+  compact: "bg-indigo-400",
+};
+
+function formatRelativeTime(timestamp: string): string {
+  const now = Date.now();
+  const then = new Date(timestamp).getTime();
+  const diffMs = now - then;
+
+  if (diffMs < 60_000) return "just now";
+  if (diffMs < 3_600_000) return `${Math.floor(diffMs / 60_000)}m ago`;
+  if (diffMs < 86_400_000) return `${Math.floor(diffMs / 3_600_000)}h ago`;
+  return `${Math.floor(diffMs / 86_400_000)}d ago`;
+}
+
+function TimelineEntryRow({
+  entry,
+  isFirst,
+}: {
+  entry: GroupedTimelineEntry;
+  isFirst: boolean;
+}) {
+  const dotColor = DOT_COLORS[entry.event_type] ?? "bg-slate-500";
+
+  return (
+    <motion.div
+      initial={isFirst ? { opacity: 0, y: -8 } : false}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3, ease: [0.25, 0.8, 0.25, 1] }}
+      className="flex items-start gap-4 px-6 py-3 hover:bg-white/[0.03] transition-colors"
+    >
+      {/* Dot + line */}
+      <div className="flex flex-col items-center pt-1 shrink-0 w-3">
+        <div className={`w-[8px] h-[8px] rounded-full ${dotColor}`} />
+        <div className="w-px flex-1 bg-slate-700/40 min-h-[8px] mt-1" />
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0">
+        <p className="text-sm text-slate-200 leading-relaxed">
+          {entry.summary}
+        </p>
+        {entry.count > 1 && (
+          <p className="text-[11px] text-slate-500 mt-0.5">
+            {entry.count} events grouped
+          </p>
+        )}
+      </div>
+
+      {/* Timestamp */}
+      <span className="text-[11px] text-slate-600 font-mono shrink-0 pt-0.5">
+        {formatRelativeTime(entry.timestamp)}
+      </span>
+    </motion.div>
+  );
+}
+
+export function SessionTimeline({
+  sessionId,
+  isOpen,
+  onDismiss,
+}: SessionTimelineProps) {
+  const { entries, loading } = useTimelineEvents(sessionId, isOpen);
+
+  // Reverse for newest-at-top
+  const reversedEntries = [...entries].reverse();
+
+  return (
+    <div className="flex flex-col h-full bg-[#1E1E2E]/95 backdrop-blur-sm">
+      {/* Header */}
+      <div
+        className="flex items-center justify-between px-6 py-3 border-b border-white/[0.06] shrink-0"
+        onMouseDown={(e) => e.preventDefault()}
+      >
+        <div className="flex items-center gap-3">
+          <span className="text-xs font-medium text-slate-400 uppercase tracking-wider">
+            Timeline
+          </span>
+          {entries.length > 0 && (
+            <span className="text-[11px] text-slate-600">
+              {entries.reduce((sum, e) => sum + e.count, 0)} events
+            </span>
+          )}
+        </div>
+        <button
+          onClick={onDismiss}
+          className="text-xs text-slate-500 hover:text-slate-300 transition-colors"
+        >
+          Dismiss
+        </button>
+      </div>
+
+      {/* Timeline entries — scrollable, newest at top */}
+      <div className="flex-1 overflow-y-auto scrollbar-thin">
+        {loading && entries.length === 0 ? (
+          <div className="flex items-center justify-center h-full">
+            <p className="text-xs text-slate-600">Loading timeline...</p>
+          </div>
+        ) : entries.length === 0 ? (
+          <div className="flex items-center justify-center h-full">
+            <p className="text-sm text-slate-600 text-center leading-relaxed">
+              Events will appear here
+              <br />
+              as this session works.
+            </p>
+          </div>
+        ) : (
+          <div className="py-2">
+            {reversedEntries.map((entry, i) => (
+              <TimelineEntryRow
+                key={entry.id}
+                entry={entry}
+                isFirst={i === 0}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Bottom edge affordance */}
+      <div className="h-px bg-gradient-to-r from-transparent via-slate-700/30 to-transparent" />
+    </div>
+  );
+}

--- a/src/components/SessionTimeline.tsx
+++ b/src/components/SessionTimeline.tsx
@@ -16,7 +16,11 @@ const DOT_COLORS: Record<string, string> = {
   status: "bg-slate-500",
   lifecycle: "bg-[#8B3A62]",
   compact: "bg-indigo-400",
+  user_input: "bg-indigo-400",
 };
+
+// High-priority events get a subtle background highlight
+const HIGH_PRIORITY_TYPES = new Set(["notification", "lifecycle"]);
 
 function formatRelativeTime(timestamp: string): string {
   const now = Date.now();
@@ -29,44 +33,125 @@ function formatRelativeTime(timestamp: string): string {
   return `${Math.floor(diffMs / 86_400_000)}d ago`;
 }
 
-function TimelineEntryRow({
-  entry,
+/** A turn is a user prompt followed by Claude's actions until the next prompt or end. */
+interface Turn {
+  userPrompt?: GroupedTimelineEntry;
+  actions: GroupedTimelineEntry[];
+  outcome?: GroupedTimelineEntry; // The Stop/status entry that ends the turn
+}
+
+/** Split a reversed (newest-first) entry list into turns. */
+function splitIntoTurns(entries: GroupedTimelineEntry[]): Turn[] {
+  const turns: Turn[] = [];
+  let current: Turn = { actions: [] };
+
+  for (const entry of entries) {
+    if (entry.event_type === "user_input") {
+      // User prompt starts a new turn — save current and start fresh
+      current.userPrompt = entry;
+      turns.push(current);
+      current = { actions: [] };
+    } else if (entry.event_type === "status") {
+      // Stop/idle event — this is the outcome of the current turn
+      current.outcome = entry;
+    } else {
+      current.actions.push(entry);
+    }
+  }
+
+  // Push remaining turn
+  if (current.actions.length > 0 || current.outcome || current.userPrompt) {
+    turns.push(current);
+  }
+
+  return turns;
+}
+
+function ActionRow({ entry }: { entry: GroupedTimelineEntry }) {
+  const dotColor = DOT_COLORS[entry.event_type] ?? "bg-slate-500";
+  const isHighPriority = HIGH_PRIORITY_TYPES.has(entry.event_type);
+
+  return (
+    <div
+      className={`flex items-start gap-3 py-1.5 pl-5 ${
+        isHighPriority ? "text-slate-200" : "text-slate-400"
+      }`}
+    >
+      <div className={`w-[6px] h-[6px] rounded-full ${dotColor} mt-1.5 shrink-0 ${
+        isHighPriority ? "ring-2 ring-amber-400/20" : ""
+      }`} />
+      <p className="text-[13px] leading-relaxed truncate flex-1 min-w-0">
+        {entry.summary}
+      </p>
+      {entry.count > 1 && (
+        <span className="text-[10px] text-slate-600 shrink-0">
+          {entry.count}×
+        </span>
+      )}
+      <span className="text-[10px] text-slate-600 font-mono shrink-0">
+        {formatRelativeTime(entry.timestamp)}
+      </span>
+    </div>
+  );
+}
+
+function TurnSection({
+  turn,
   isFirst,
 }: {
-  entry: GroupedTimelineEntry;
+  turn: Turn;
   isFirst: boolean;
 }) {
-  const dotColor = DOT_COLORS[entry.event_type] ?? "bg-slate-500";
+  const hasPrompt = !!turn.userPrompt;
 
   return (
     <motion.div
       initial={isFirst ? { opacity: 0, y: -8 } : false}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.3, ease: [0.25, 0.8, 0.25, 1] }}
-      className="flex items-start gap-4 px-6 py-3 hover:bg-white/[0.03] transition-colors"
+      className="px-6 py-3"
     >
-      {/* Dot + line */}
-      <div className="flex flex-col items-center pt-1 shrink-0 w-3">
-        <div className={`w-[8px] h-[8px] rounded-full ${dotColor}`} />
-        <div className="w-px flex-1 bg-slate-700/40 min-h-[8px] mt-1" />
-      </div>
+      {/* User prompt — turn header */}
+      {hasPrompt && (
+        <div className="flex items-start gap-3 mb-2">
+          <div className="w-[6px] h-[6px] rounded-full bg-indigo-400 mt-2 shrink-0 ring-2 ring-indigo-400/20" />
+          <div className="flex-1 min-w-0">
+            <span className="text-[10px] text-indigo-400/70 uppercase tracking-wider">
+              You
+            </span>
+            <p className="text-sm text-slate-100 leading-relaxed mt-0.5 line-clamp-2">
+              {turn.userPrompt!.summary}
+            </p>
+          </div>
+          <span className="text-[10px] text-slate-600 font-mono shrink-0 pt-1.5">
+            {formatRelativeTime(turn.userPrompt!.timestamp)}
+          </span>
+        </div>
+      )}
 
-      {/* Content */}
-      <div className="flex-1 min-w-0">
-        <p className="text-sm text-slate-200 leading-relaxed">
-          {entry.summary}
-        </p>
-        {entry.count > 1 && (
-          <p className="text-[11px] text-slate-500 mt-0.5">
-            {entry.count} events grouped
-          </p>
-        )}
-      </div>
+      {/* Claude's actions */}
+      {turn.actions.length > 0 && (
+        <div className={`${hasPrompt ? "ml-2 border-l border-slate-700/30 pl-2" : ""}`}>
+          {turn.actions.map((entry) => (
+            <ActionRow key={entry.id} entry={entry} />
+          ))}
+        </div>
+      )}
 
-      {/* Timestamp */}
-      <span className="text-[11px] text-slate-600 font-mono shrink-0 pt-0.5">
-        {formatRelativeTime(entry.timestamp)}
-      </span>
+      {/* Outcome — what Claude concluded */}
+      {turn.outcome && (
+        <div className={`mt-2 ${hasPrompt ? "ml-2 pl-2" : ""}`}>
+          <div className="flex items-start gap-3 py-1.5 px-3 rounded-lg bg-white/[0.02]">
+            <div className="w-[6px] h-[6px] rounded-full bg-slate-500 mt-1.5 shrink-0" />
+            <p className="text-[13px] text-slate-400 leading-relaxed flex-1 min-w-0 line-clamp-2">
+              {turn.outcome.summary}
+            </p>
+            <span className="text-[10px] text-slate-600 font-mono shrink-0">
+              {formatRelativeTime(turn.outcome.timestamp)}
+            </span>
+          </div>
+        </div>
+      )}
     </motion.div>
   );
 }
@@ -78,22 +163,22 @@ export function SessionTimeline({
 }: SessionTimelineProps) {
   const { entries, loading } = useTimelineEvents(sessionId, isOpen);
 
-  // Reverse for newest-at-top
   const reversedEntries = [...entries].reverse();
+  const turns = splitIntoTurns(reversedEntries);
 
   return (
-    <div className="flex flex-col h-full bg-[#1E1E2E]/95 backdrop-blur-sm">
+    <div className="flex flex-col h-full bg-[#181825] relative">
       {/* Header */}
       <div
-        className="flex items-center justify-between px-6 py-3 border-b border-white/[0.06] shrink-0"
+        className="flex items-center justify-between px-6 py-3.5 border-b border-white/[0.06] shrink-0"
         onMouseDown={(e) => e.preventDefault()}
       >
         <div className="flex items-center gap-3">
-          <span className="text-xs font-medium text-slate-400 uppercase tracking-wider">
+          <span className="text-xs font-semibold text-slate-300 uppercase tracking-wider">
             Timeline
           </span>
           {entries.length > 0 && (
-            <span className="text-[11px] text-slate-600">
+            <span className="text-[11px] text-slate-600 font-mono">
               {entries.reduce((sum, e) => sum + e.count, 0)} events
             </span>
           )}
@@ -106,7 +191,7 @@ export function SessionTimeline({
         </button>
       </div>
 
-      {/* Timeline entries — scrollable, newest at top */}
+      {/* Timeline turns — scrollable, newest at top */}
       <div className="flex-1 overflow-y-auto scrollbar-thin">
         {loading && entries.length === 0 ? (
           <div className="flex items-center justify-center h-full">
@@ -121,11 +206,11 @@ export function SessionTimeline({
             </p>
           </div>
         ) : (
-          <div className="py-2">
-            {reversedEntries.map((entry, i) => (
-              <TimelineEntryRow
-                key={entry.id}
-                entry={entry}
+          <div className="py-1 divide-y divide-white/[0.04]">
+            {turns.map((turn, i) => (
+              <TurnSection
+                key={turn.userPrompt?.id ?? turn.actions[0]?.id ?? `turn-${i}`}
+                turn={turn}
                 isFirst={i === 0}
               />
             ))}
@@ -133,8 +218,9 @@ export function SessionTimeline({
         )}
       </div>
 
-      {/* Bottom edge affordance */}
-      <div className="h-px bg-gradient-to-r from-transparent via-slate-700/30 to-transparent" />
+      {/* Bottom glow edge — visual separation from terminal below */}
+      <div className="absolute bottom-0 inset-x-0 h-16 pointer-events-none bg-gradient-to-t from-[#181825] via-[#181825]/80 to-transparent" />
+      <div className="absolute bottom-0 inset-x-0 h-px bg-gradient-to-r from-indigo-500/20 via-indigo-400/30 to-indigo-500/20" />
     </div>
   );
 }

--- a/src/components/TerminalOverlay.tsx
+++ b/src/components/TerminalOverlay.tsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { TerminalPane, type TerminalPaneHandle } from "./TerminalPane";
+import { SessionTimeline } from "./SessionTimeline";
 import { StatusDot } from "./StatusDot";
 import type { Session } from "../lib/types";
 import "@xterm/xterm/css/xterm.css";
@@ -34,6 +35,7 @@ export function TerminalOverlay({
 }: TerminalOverlayProps) {
   const [activeTabId, setActiveTabId] = useState(session.id);
   const [showMenu, setShowMenu] = useState(false);
+  const [timelineOpen, setTimelineOpen] = useState(false);
   const paneRefs = useRef<Map<string, TerminalPaneHandle>>(new Map());
 
   const allTabs = [session, ...companions];
@@ -45,12 +47,20 @@ export function TerminalOverlay({
     }
   }, [allTabs, activeTabId, session.id]);
 
+  // Close timeline when overlay closes
+  useEffect(() => {
+    if (!isOpen) setTimelineOpen(false);
+  }, [isOpen]);
+
   // Keyboard shortcuts
   useEffect(() => {
     if (!isOpen) return;
     const handler = (e: KeyboardEvent) => {
-      // Escape only closes the actions menu — never the overlay
       if (e.key === "Escape") {
+        if (timelineOpen) {
+          setTimelineOpen(false);
+          return;
+        }
         if (showMenu) {
           setShowMenu(false);
         }
@@ -82,6 +92,13 @@ export function TerminalOverlay({
       if (e.metaKey && e.shiftKey && e.key === "E") {
         e.preventDefault();
         onEnd(session.id);
+        return;
+      }
+
+      // ⌘. → toggle timeline
+      if (e.metaKey && e.key === ".") {
+        e.preventDefault();
+        setTimelineOpen((v) => !v);
         return;
       }
 
@@ -117,7 +134,7 @@ export function TerminalOverlay({
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [isOpen, onClose, onRestart, onPark, onEnd, showMenu, session, companions, activeTabId, onAddCompanion, onRemoveCompanion]);
+  }, [isOpen, onClose, onRestart, onPark, onEnd, showMenu, timelineOpen, session, companions, activeTabId, onAddCompanion, onRemoveCompanion]);
 
   // Drag-drop file handling — writes to active tab
   useEffect(() => {
@@ -158,6 +175,7 @@ export function TerminalOverlay({
   );
 
   const hasCompanions = companions.length > 0;
+  const showTimelineButton = activeSession.hookEnabled !== false && activeSession.session_type !== "terminal";
 
   return (
     <motion.div
@@ -190,7 +208,7 @@ export function TerminalOverlay({
         transition={{ duration: 0.4, ease: [0.25, 0.8, 0.25, 1] }}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-3 py-2.5 bg-[#181825] border-b border-slate-700/50" onMouseDown={(e) => e.preventDefault()}>
+        <div className="flex items-center justify-between px-3 py-2.5 bg-[#181825] border-b border-slate-700/50 relative z-20" onMouseDown={(e) => e.preventDefault()}>
           <div className="flex items-center gap-3">
             {/* Back arrow — return to home */}
             <button
@@ -212,6 +230,21 @@ export function TerminalOverlay({
           </div>
 
           <div className="flex items-center gap-1.5">
+            {/* Catch me up button */}
+            {showTimelineButton && (
+              <button
+                onClick={() => setTimelineOpen((v) => !v)}
+                className={`px-2.5 py-1 rounded-md text-xs transition-colors ${
+                  timelineOpen
+                    ? "text-slate-200 bg-slate-700/50"
+                    : "text-slate-500 hover:text-slate-300 hover:bg-slate-700/50"
+                }`}
+                title="Catch me up (⌘.)"
+              >
+                Catch me up
+              </button>
+            )}
+
             {/* + Terminal link (when no companions yet) */}
             {!hasCompanions && (
               <button
@@ -293,7 +326,7 @@ export function TerminalOverlay({
 
         {/* Tab bar — shown only when companions exist */}
         {hasCompanions && (
-          <div className="flex items-center bg-[#181825] border-b border-slate-700/50 px-2" onMouseDown={(e) => e.preventDefault()}>
+          <div className="flex items-center bg-[#181825] border-b border-slate-700/50 px-2 relative z-20" onMouseDown={(e) => e.preventDefault()}>
             {allTabs.map((tab, idx) => {
               const isActive = tab.id === activeTabId;
               const isCompanion = tab.id !== session.id;
@@ -332,8 +365,9 @@ export function TerminalOverlay({
           </div>
         )}
 
-        {/* Terminal panes — all mounted, only active visible */}
-        <div className="flex-1 flex flex-col min-h-0">
+        {/* Terminal panes + timeline overlay container */}
+        <div className="flex-1 flex flex-col min-h-0 relative">
+          {/* Terminal panes — all mounted, only active visible */}
           {allTabs.map((tab) => (
             <TerminalPane
               key={tab.id}
@@ -348,6 +382,38 @@ export function TerminalOverlay({
               visible={tab.id === activeTabId && isOpen}
             />
           ))}
+
+          {/* Timeline pull-down overlay — slides down over terminal */}
+          <AnimatePresence>
+            {timelineOpen && (
+              <>
+                {/* Dim layer over terminal — click to dismiss */}
+                <motion.div
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.3, ease: [0.25, 0.8, 0.25, 1] }}
+                  className="absolute inset-0 bg-black/40 z-10"
+                  onClick={() => setTimelineOpen(false)}
+                />
+
+                {/* Timeline content — slides down from top */}
+                <motion.div
+                  initial={{ y: "-100%" }}
+                  animate={{ y: 0 }}
+                  exit={{ y: "-100%" }}
+                  transition={{ duration: 0.4, ease: [0.25, 0.8, 0.25, 1] }}
+                  className="absolute inset-x-0 top-0 z-20 h-[75%] overflow-hidden"
+                >
+                  <SessionTimeline
+                    sessionId={activeSession.id}
+                    isOpen={timelineOpen}
+                    onDismiss={() => setTimelineOpen(false)}
+                  />
+                </motion.div>
+              </>
+            )}
+          </AnimatePresence>
         </div>
       </motion.div>
     </motion.div>

--- a/src/components/TerminalOverlay.tsx
+++ b/src/components/TerminalOverlay.tsx
@@ -5,6 +5,7 @@ import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { TerminalPane, type TerminalPaneHandle } from "./TerminalPane";
 import { SessionTimeline } from "./SessionTimeline";
 import { StatusDot } from "./StatusDot";
+import { trackEvent } from "../lib/telemetry";
 import type { Session } from "../lib/types";
 import "@xterm/xterm/css/xterm.css";
 
@@ -51,6 +52,13 @@ export function TerminalOverlay({
   useEffect(() => {
     if (!isOpen) setTimelineOpen(false);
   }, [isOpen]);
+
+  // Track timeline usage
+  useEffect(() => {
+    if (timelineOpen) {
+      trackEvent("timeline.opened", "timeline", undefined, activeSession.id);
+    }
+  }, [timelineOpen, activeSession.id]);
 
   // Keyboard shortcuts
   useEffect(() => {
@@ -387,23 +395,26 @@ export function TerminalOverlay({
           <AnimatePresence>
             {timelineOpen && (
               <>
-                {/* Dim layer over terminal — click to dismiss */}
+                {/* Dim layer over terminal — captures clicks to dismiss, blocks terminal interaction */}
                 <motion.div
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1 }}
                   exit={{ opacity: 0 }}
-                  transition={{ duration: 0.3, ease: [0.25, 0.8, 0.25, 1] }}
-                  className="absolute inset-0 bg-black/40 z-10"
+                  transition={{ duration: 0.35, ease: [0.25, 0.8, 0.25, 1] }}
+                  className="absolute inset-0 bg-black/50 z-10 backdrop-blur-[2px] pointer-events-auto"
                   onClick={() => setTimelineOpen(false)}
                 />
 
-                {/* Timeline content — slides down from top */}
+                {/* Timeline content — slides down from top, fades on exit */}
                 <motion.div
-                  initial={{ y: "-100%" }}
-                  animate={{ y: 0 }}
-                  exit={{ y: "-100%" }}
-                  transition={{ duration: 0.4, ease: [0.25, 0.8, 0.25, 1] }}
-                  className="absolute inset-x-0 top-0 z-20 h-[75%] overflow-hidden"
+                  initial={{ y: "-100%", opacity: 0.5 }}
+                  animate={{ y: 0, opacity: 1 }}
+                  exit={{ y: "-100%", opacity: 0 }}
+                  transition={{
+                    y: { duration: 0.4, ease: [0.25, 0.8, 0.25, 1] },
+                    opacity: { duration: 0.25, ease: "easeOut" },
+                  }}
+                  className="absolute inset-x-0 top-0 z-20 h-[75%] overflow-hidden rounded-b-2xl"
                 >
                   <SessionTimeline
                     sessionId={activeSession.id}

--- a/src/hooks/useStatus.ts
+++ b/src/hooks/useStatus.ts
@@ -1,11 +1,12 @@
 import { useEffect, useRef } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
-import {
-  isPermissionGranted,
-  requestPermission,
-  sendNotification,
-} from "@tauri-apps/plugin-notification";
+// OS notifications disabled — revisiting in a future release
+// import {
+//   isPermissionGranted,
+//   requestPermission,
+//   sendNotification,
+// } from "@tauri-apps/plugin-notification";
 import { useSessionContext } from "../context/SessionContext";
 import type { SessionStatus } from "../lib/types";
 import { playChime, playAlert, playTone } from "../lib/sounds";
@@ -17,7 +18,7 @@ interface SoundSettings {
 
 export function useStatus(sessionIds: string[]) {
   const { sessions, dispatch } = useSessionContext();
-  const notifPermissionRef = useRef<boolean | null>(null);
+  // const notifPermissionRef = useRef<boolean | null>(null);
   const soundSettingsRef = useRef<SoundSettings>({
     sounds_enabled: false,
     sound_volume: 0.5,
@@ -25,18 +26,18 @@ export function useStatus(sessionIds: string[]) {
   const sessionsRef = useRef(sessions);
   sessionsRef.current = sessions;
 
-  // Check notification permission on mount
-  useEffect(() => {
-    isPermissionGranted().then((granted) => {
-      if (granted) {
-        notifPermissionRef.current = true;
-      } else {
-        requestPermission().then((perm) => {
-          notifPermissionRef.current = perm === "granted";
-        });
-      }
-    });
-  }, []);
+  // OS notifications disabled — revisiting in a future release
+  // useEffect(() => {
+  //   isPermissionGranted().then((granted) => {
+  //     if (granted) {
+  //       notifPermissionRef.current = true;
+  //     } else {
+  //       requestPermission().then((perm) => {
+  //         notifPermissionRef.current = perm === "granted";
+  //       });
+  //     }
+  //   });
+  // }, []);
 
   // Load sound settings
   useEffect(() => {
@@ -64,14 +65,14 @@ export function useStatus(sessionIds: string[]) {
 
         dispatch({ type: "UPDATE_STATUS", id, status: newStatus });
 
-        // Fire notification on "waiting" transition
-        if (newStatus === "waiting" && notifPermissionRef.current) {
-          const session = sessionsRef.current.find((s) => s.id === id);
-          sendNotification({
-            title: "NextDialog",
-            body: `${session?.name ?? "Session"} is waiting for input`,
-          });
-        }
+        // OS notifications disabled — revisiting in a future release
+        // if (newStatus === "waiting" && notifPermissionRef.current) {
+        //   const session = sessionsRef.current.find((s) => s.id === id);
+        //   sendNotification({
+        //     title: "NextDialog",
+        //     body: `${session?.name ?? "Session"} is waiting for input`,
+        //   });
+        // }
 
         // Play sounds on status transitions
         if (

--- a/src/hooks/useTimelineEvents.ts
+++ b/src/hooks/useTimelineEvents.ts
@@ -1,0 +1,152 @@
+import { useState, useEffect, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import type { TimelineEntry, GroupedTimelineEntry } from "../lib/types";
+
+const GROUP_WINDOW_MS = 10_000;
+const MAX_GROUP_SIZE = 20;
+
+/**
+ * Build a meaningful summary for a group of entries instead of "Used N tools".
+ * Breaks down by sub-type: "Read 3 files, searched 2 patterns, edited 1 file"
+ */
+function buildGroupSummary(entries: TimelineEntry[]): string {
+  if (entries.length === 1) return entries[0].summary;
+
+  const eventType = entries[0].event_type;
+
+  // File writes: list basenames up to 3, then "+N more"
+  if (eventType === "file_write") {
+    const names = entries.map((e) => {
+      const path = e.summary.replace(/^Edited /, "");
+      return path;
+    });
+    if (names.length <= 3) return `Edited ${names.join(", ")}`;
+    return `Edited ${names.slice(0, 2).join(", ")} +${names.length - 2} more`;
+  }
+
+  // Bash: list unique activity types
+  if (eventType === "bash") {
+    const cmds = entries.map((e) => e.summary);
+    if (cmds.length <= 3) return cmds.join("; ");
+    return `${cmds.slice(0, 2).join("; ")} +${cmds.length - 2} more`;
+  }
+
+  // Tool uses: break down by tool type, preserving context
+  if (eventType === "tool") {
+    const categories: Record<string, TimelineEntry[]> = {};
+    for (const e of entries) {
+      const verb = e.summary.split(" ")[0] ?? "Used";
+      if (!categories[verb]) categories[verb] = [];
+      categories[verb].push(e);
+    }
+    const parts = Object.entries(categories)
+      .sort((a, b) => b[1].length - a[1].length)
+      .slice(0, 3)
+      .map(([verb, items]) => {
+        if (items.length === 1) {
+          return items[0].summary;
+        }
+        // For Read: "Read App.tsx, types.ts +1 more"
+        if (verb === "Read") {
+          const names = items.map((e) => e.summary.replace(/^Read /, ""));
+          if (names.length <= 2) return `Read ${names.join(", ")}`;
+          return `Read ${names[0]} +${names.length - 1} more`;
+        }
+        // For Searched: show first pattern
+        if (verb === "Searched") {
+          return `${items[0].summary} +${items.length - 1} more`;
+        }
+        return `${verb} ${items.length}×`;
+      });
+    return parts.join(", ");
+  }
+
+  return `${entries.length} events`;
+}
+
+function groupEntries(raw: TimelineEntry[]): GroupedTimelineEntry[] {
+  const groups: GroupedTimelineEntry[] = [];
+
+  for (const entry of raw) {
+    const last = groups[groups.length - 1];
+    if (
+      last &&
+      last.event_type === entry.event_type &&
+      last.count < MAX_GROUP_SIZE &&
+      Math.abs(
+        new Date(entry.timestamp).getTime() -
+          new Date(last.timestamp).getTime(),
+      ) < GROUP_WINDOW_MS
+    ) {
+      last.entries.push(entry);
+      last.count = last.entries.length;
+      last.timestamp = entry.timestamp;
+      last.summary = buildGroupSummary(last.entries);
+    } else {
+      groups.push({
+        id: entry.timestamp,
+        timestamp: entry.timestamp,
+        event_type: entry.event_type,
+        summary: entry.summary,
+        count: 1,
+        entries: [entry],
+      });
+    }
+  }
+
+  return groups;
+}
+
+export function useTimelineEvents(sessionId: string, isOpen: boolean) {
+  const [rawEntries, setRawEntries] = useState<TimelineEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const loadedRef = useRef(false);
+
+  // Load historical entries on first open
+  useEffect(() => {
+    if (!isOpen || loadedRef.current) return;
+    loadedRef.current = true;
+
+    invoke<TimelineEntry[]>("get_timeline_entries", {
+      id: sessionId,
+      count: 50,
+    })
+      .then((entries) => {
+        setRawEntries(entries);
+        setLoading(false);
+      })
+      .catch(() => {
+        setLoading(false);
+      });
+  }, [sessionId, isOpen]);
+
+  // Subscribe to real-time timeline events
+  useEffect(() => {
+    let cleanup: (() => void) | undefined;
+    let cancelled = false;
+
+    listen<TimelineEntry>(
+      `session-timeline-${sessionId}`,
+      (event) => {
+        if (cancelled) return;
+        setRawEntries((prev) => [...prev.slice(-99), event.payload]);
+      },
+    ).then((unlisten) => {
+      if (cancelled) {
+        unlisten();
+      } else {
+        cleanup = unlisten;
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      cleanup?.();
+    };
+  }, [sessionId]);
+
+  const entries = groupEntries(rawEntries);
+
+  return { entries, loading };
+}

--- a/src/hooks/useTimelineEvents.ts
+++ b/src/hooks/useTimelineEvents.ts
@@ -68,10 +68,14 @@ function buildGroupSummary(entries: TimelineEntry[]): string {
 function groupEntries(raw: TimelineEntry[]): GroupedTimelineEntry[] {
   const groups: GroupedTimelineEntry[] = [];
 
+  // Types that should never be grouped — they're turn boundaries
+  const NEVER_GROUP = new Set(["user_input", "status", "notification", "lifecycle"]);
+
   for (const entry of raw) {
     const last = groups[groups.length - 1];
     if (
       last &&
+      !NEVER_GROUP.has(entry.event_type) &&
       last.event_type === entry.event_type &&
       last.count < MAX_GROUP_SIZE &&
       Math.abs(

--- a/src/hooks/useUpdateCheck.ts
+++ b/src/hooks/useUpdateCheck.ts
@@ -1,0 +1,77 @@
+import { useState, useEffect } from "react";
+import { getVersion } from "@tauri-apps/api/app";
+
+interface UpdateInfo {
+  currentVersion: string;
+  latestVersion: string;
+  downloadUrl: string;
+}
+
+const GITHUB_REPO = "brianwcline/nextdialog";
+const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // 4 hours
+
+function compareVersions(current: string, latest: string): boolean {
+  const parse = (v: string) =>
+    v.replace(/^v/, "").split(".").map(Number);
+  const c = parse(current);
+  const l = parse(latest);
+  for (let i = 0; i < Math.max(c.length, l.length); i++) {
+    const cv = c[i] ?? 0;
+    const lv = l[i] ?? 0;
+    if (lv > cv) return true;
+    if (lv < cv) return false;
+  }
+  return false;
+}
+
+async function checkForUpdate(): Promise<UpdateInfo | null> {
+  try {
+    const currentVersion = await getVersion();
+    const resp = await fetch(
+      `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`,
+      {
+        headers: { Accept: "application/vnd.github.v3+json" },
+      },
+    );
+    if (!resp.ok) return null;
+
+    const data = await resp.json();
+    const latestTag: string = data.tag_name ?? "";
+    const latestVersion = latestTag.replace(/^v/, "");
+    const downloadUrl: string = data.html_url ?? `https://github.com/${GITHUB_REPO}/releases`;
+
+    if (compareVersions(currentVersion, latestVersion)) {
+      return { currentVersion, latestVersion, downloadUrl };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function useUpdateCheck() {
+  const [update, setUpdate] = useState<UpdateInfo | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    // Check on mount (slight delay to not block startup)
+    const initialTimer = setTimeout(() => {
+      checkForUpdate().then(setUpdate);
+    }, 5000);
+
+    // Re-check periodically
+    const interval = setInterval(() => {
+      checkForUpdate().then(setUpdate);
+    }, CHECK_INTERVAL_MS);
+
+    return () => {
+      clearTimeout(initialTimer);
+      clearInterval(interval);
+    };
+  }, []);
+
+  return {
+    update: dismissed ? null : update,
+    dismiss: () => setDismissed(true),
+  };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -25,6 +25,22 @@ export interface Session {
   hookNotification?: string;
 }
 
+export interface TimelineEntry {
+  timestamp: string;
+  event_type: string;
+  summary: string;
+  details?: Record<string, unknown>;
+}
+
+export interface GroupedTimelineEntry {
+  id: string;
+  timestamp: string;
+  event_type: string;
+  summary: string;
+  count: number;
+  entries: TimelineEntry[];
+}
+
 export interface AgentConfig {
   permission_mode?: string;
   allowed_tools: string[];


### PR DESCRIPTION
## Summary

- **Session Timeline ("Catch me up")** — Pull-down overlay inside the terminal showing a turn-based history of what happened in each session. User prompts as section headers, Claude's actions indented below, outcomes as closing cards. Triggered via "Catch me up" button or ⌘.
- **Multi-session hook fix** — Port-scoped hook config so multiple sessions in the same directory don't clobber each other's `.claude/settings.local.json` entries (fixes ECONNREFUSED errors)
- **Update checker** — Fetches latest GitHub release on launch, shows "v0.X.X available" in home header when a new version exists
- **Disable OS notifications** — Banner notifications were spamming when switching windows; disabled pending redesign

### Timeline details
- Backend: JSONL event ledger per session at `~/.nextdialog/timelines/`, rich summaries extracted from hook `tool_input` (file paths, commands, search patterns, agent descriptions)
- User input captured from PTY stream (detects ❯/›/> prompt patterns)
- Stop events capture terminal preview lines for context-aware summaries
- Filters Claude Code spinner/progress noise from preview lines
- Telemetry: `timeline.opened` event tracks adoption
- 22 Rust tests passing, clippy clean, tsc clean

## Test plan

- [ ] Open terminal overlay, click "Catch me up" — timeline slides down with events
- [ ] ⌘. toggles timeline, Escape dismisses, click dim area dismisses
- [ ] Open 2 sessions in same directory — both get hook events without ECONNREFUSED
- [ ] End one session — other continues receiving hooks
- [ ] Check home header for "v0.X.X available" (if a newer release exists)
- [ ] Terminal scroll, resize, TUI interactivity unaffected by timeline overlay
- [ ] Session card shows last timeline event as preview text

🤖 Generated with [Claude Code](https://claude.com/claude-code)